### PR TITLE
Implement trap on indirect call type mismatch

### DIFF
--- a/source/m3.h
+++ b/source/m3.h
@@ -149,6 +149,7 @@ d_m3ErrorConst  (trapOutOfBoundsMemoryAccess,   "[trap] out of bounds memory acc
 d_m3ErrorConst  (trapDivisionByZero,            "[trap] integer divide by zero")
 d_m3ErrorConst  (trapIntegerOverflow,           "[trap] integer overflow")
 d_m3ErrorConst  (trapIntegerConversion,         "[trap] invalid conversion to integer")
+d_m3ErrorConst  (trapIndirectCallTypeMismatch,  "[trap] indirect call type mismatch")
 d_m3ErrorConst  (trapTableIndexOutOfRange,      "[trap] undefined element")
 d_m3ErrorConst  (trapExit,                      "[trap] program called exit")
 d_m3ErrorConst  (trapUnreachable,               "[trap] unreachable executed")

--- a/source/m3_exec.c
+++ b/source/m3_exec.c
@@ -43,7 +43,6 @@ d_m3OpDef  (Call)
 }
 
 
-// TODO: should trap "indirect call type mismatch"
 d_m3OpDef  (CallIndirect)
 {
     IM3Module module            = immediate (IM3Module);
@@ -62,6 +61,24 @@ d_m3OpDef  (CallIndirect)
 
         if (function)
         {
+            if (type->numArgs != function->funcType->numArgs)
+            {
+                return c_m3Err_trapIndirectCallTypeMismatch;
+            }
+
+            if (type->returnType != function->funcType->returnType)
+            {
+                return c_m3Err_trapIndirectCallTypeMismatch;
+            }
+
+            for (u32 argIndex = 0; argIndex < type->numArgs; ++argIndex)
+            {
+                if (type->argTypes[argIndex] != function->funcType->argTypes[argIndex])
+                {
+                    return c_m3Err_trapIndirectCallTypeMismatch;
+                }
+            }
+
             if (not function->compiled)
                 r = Compile_Function (function);
 


### PR DESCRIPTION
Fixes #2 

I ran the applicable tests and they pass now.

Note that not all the call indirect tests pass, but the remaining failure I believe is for a different and unrelated reason (looks like a stack overflow on `call_indirect.wast:263`).