### PR TITLE
Minor changes to m3_GetMemory

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -852,11 +852,11 @@ M3StackInfo  m3_GetNativeStackInfo  (i32 i_stackSize)
     return info;
 }
 
-
-bytes_t  m3_GetMemory  (IM3Runtime i_runtime, u32 * o_memorySizeInBytes, u32 i_memoryIndex)
+const uint8_t *  m3_GetMemory  (IM3Runtime i_runtime, uint32_t * o_memorySizeInBytes, uint32_t i_memoryIndex)
 {
-    bytes_t memory = NULL;                          d_m3Assert (i_memoryIndex == 0);
-    
+    uint8_t * memory = NULL;                          
+    d_m3Assert (i_memoryIndex == 0);
+
     if (i_runtime)
     {
         u32 size = (u32) i_runtime->memory.mallocated->length;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -248,9 +248,6 @@ IM3CodePage                 AcquireCodePage             (IM3Runtime io_runtime);
 IM3CodePage                 AcquireCodePageWithCapacity (IM3Runtime io_runtime, u32 i_slotCount);
 void                        ReleaseCodePage             (IM3Runtime io_runtime, IM3CodePage i_codePage);
 
-bytes_t                     m3_GetMemory                 (IM3Runtime i_runtime, u32 * o_memorySizeInBytes, u32 i_memoryIndex);
-
-
 M3Result                    m3Error                     (M3Result i_result, IM3Runtime i_runtime, IM3Module i_module, IM3Function i_function, const char * const i_file, u32 i_lineNum, const char * const i_errorMessage, ...);
 
 


### PR DESCRIPTION
Deleted `m3_GetMemory()` declaration in `m3_env.h` as there it is also declared (with a slightly different signature) in `m3.h`

Adapted function definition in `m3_env.c` to conform to the remaining `m3.h` function declaration.

(Tested linear memory access by invoking get/set string functions through raw pointer returned by `m3_GetMemory()`: works correctly!)