### PR TITLE
wasi/main: return exit code on wasi proc_exit call

### DIFF
--- a/platforms/app/main.c
+++ b/platforms/app/main.c
@@ -273,6 +273,9 @@ int  main  (int i_argc, const char* i_argv[])
             } else {
                 result = repl_call(runtime, argFunc, i_argc, i_argv);
             }
+            if (result == m3Err_trapExit) {
+                return runtime->exit_code;
+            }
             if (result) FATAL("repl_call: %s", result);
         }
     }
@@ -314,6 +317,10 @@ int  main  (int i_argc, const char* i_argv[])
             M3ErrorInfo info;
             m3_GetErrorInfo (runtime, &info);
             fprintf (stderr, " (%s)\n", info.message);
+            if (result == m3Err_trapExit) {
+                // warn that exit was called
+                fprintf(stderr, M3_ARCH "-wasi: exit(%d)\n", runtime->exit_code);
+            }
         }
     }
 

--- a/source/m3_api_wasi.c
+++ b/source/m3_api_wasi.c
@@ -618,10 +618,9 @@ m3ApiRawFunction(m3_wasi_unstable_proc_exit)
     m3ApiReturnType  (uint32_t)
     m3ApiGetArg      (uint32_t, code)
 
-    // TODO: in repl mode, trap and bail out
-    if (code) {
-        fprintf(stderr, M3_ARCH "-wasi: exit(%d)\n", code);
-    }
+    if (runtime == NULL) { m3ApiReturn(__WASI_EINVAL); }
+
+    runtime->exit_code = code;
 
     m3ApiTrap(m3Err_trapExit);
 }

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -228,6 +228,7 @@ typedef struct M3Runtime
 #if defined(d_m3VerboseLogs)
     char                    error_message[256];
 #endif
+    i32                     exit_code;
 }
 M3Runtime;
 


### PR DESCRIPTION
This is a proposed PR for fixing #58 

When running a file (non-REPL mode), if the proc_exit call is called,
then terminate with the exit code. If in REPL mode then print
a message with the exit code to indicate the wasi call was made and
continue.