### PR TITLE
WIP: PoC: an alternative to tail calls (for Xtensa)

### DIFF
--- a/platforms/esp32-idf/main/CMakeLists.txt
+++ b/platforms/esp32-idf/main/CMakeLists.txt
@@ -23,4 +23,4 @@ else()
     target_link_libraries(${COMPONENT_TARGET} PRIVATE m3)
 endif()
 
-target_compile_options(m3 PUBLIC -DM3_IN_IRAM -DESP32 -Dd_m3LogOutput=false)
+target_compile_options(m3 PUBLIC -O3 -DM3_IN_IRAM -DESP32 -Dd_m3LogOutput=false -ggdb)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -15,6 +15,10 @@ set(srcs
     "m3_parse.c"
 )
 
+if (CMAKE_C_COMPILER MATCHES "xtensa-")
+    list(APPEND srcs m3_xtensa.S)
+endif()
+
 add_library(m3 STATIC ${srcs})
 
 target_include_directories(m3 PUBLIC .)

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -223,7 +223,10 @@ M3Result  EvaluateExpression  (IM3Module i_module, void * o_expressed, u8 i_type
 
         if (not result)
         {
-            m3ret_t r = Call (m3code, stack, NULL, d_m3OpDefaultArgs);
+            M3MemoryHeader *_mem;
+            d_updateMem(NULL);
+
+            m3ret_t r = Call (m3code, stack, d_m3OpDefaultArgs);
             result = runtime.runtimeError;
 
             if (r == 0 and not result)
@@ -604,7 +607,9 @@ M3Result  m3_CallWithArgs  (IM3Function i_function, uint32_t i_argc, const char 
         }
 
         m3StackCheckInit();
-_       ((M3Result)Call (i_function->compiled, stack, runtime->memory.mallocated, d_m3OpDefaultArgs));
+        M3MemoryHeader *_mem;
+        d_updateMem(runtime->memory.mallocated);
+_       ((M3Result)Call (i_function->compiled, stack, d_m3OpDefaultArgs));
 
 #if d_m3LogOutput
         switch (ftype->returnType) {

--- a/source/m3_exec_defs.h
+++ b/source/m3_exec_defs.h
@@ -10,13 +10,51 @@
 
 #include "m3_core.h"
 
+// actually this is "no tail calls" + "use less function args"
+// Probably need to make this whole set of defines, plus some in m3_exec.h, overridable in an arch-specific header.
+#define d_m3NoTailCalls 1
+
+#ifndef d_m3NoTailCalls
 #   define d_m3OpSig                pc_t _pc, u64 * _sp, M3MemoryHeader * _mem, m3reg_t _r0, f64 _fp0
 #   define d_m3OpArgs               _sp, _mem, _r0, _fp0
 #   define d_m3OpAllArgs            _pc, _sp, _mem, _r0, _fp0
+#   define d_m3OpDefaultArgs        _mem, 666, NAN
+#   define d_usesMemory(mem)
+#   define d_updateMem(mem)         _mem = mem
+#   define m3MemData(mem)           (u8*)((M3MemoryHeader*)(mem)+1)
+typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig);
+
+#else // d_m3NoTailCalls
+
+// Xtensa note: first two args are 32-bit pointers, 3rd and 4th are 64-bit values.
+// In total they occupy the max. number of registers which can be used for function arguments on Xtensa
+// Any extra args would have to go onto the stack.
+// Unlike the !d_m3NoTailCalls case above, _mem becomes a global (but can be made thread local if needed).
+#   define d_m3OpSig                pc_t _pc, u64 * _sp, m3reg_t _r0, f64 _fp0
+#   define d_m3OpArgs               _sp, _r0, _fp0
+#   define d_m3OpAllArgs            _pc, _sp, _r0, _fp0
 #   define d_m3OpDefaultArgs        666, NAN
 
 #   define m3MemData(mem)           (u8*)((M3MemoryHeader*)(mem)+1)
+extern M3MemoryHeader * g_mem;
+#   define d_usesMemory(mem)       M3MemoryHeader * mem = g_mem;
+#   define d_updateMem(mem)        g_mem = mem
 
-typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig);
+typedef struct {
+    union {
+        pc_t pc;
+        m3ret_t err;
+    };
+    m3stack_t sp;
+    m3reg_t r0;
+    f64 fp0;
+} m3_ret_struct_t;
+
+#define d_m3OpRetError(e)  return (m3_ret_struct_t) {.err=e, .sp=0, .r0 = 0, .fp0 = 0}
+#define d_m3OpRetTailCall(pc_)  return (m3_ret_struct_t) {.pc=pc_, .sp=_sp, .r0 = _r0, .fp0 = _fp0}
+typedef m3_ret_struct_t (vectorcall * IM3Operation) (d_m3OpSig);
+
+#endif // d_m3NoTailCalls
+
 
 #endif // m3_exec_defs_h

--- a/source/m3_exec_defs.h
+++ b/source/m3_exec_defs.h
@@ -20,6 +20,8 @@
 #   define d_m3OpAllArgs            _pc, _sp, _mem, _r0, _fp0
 #   define d_m3OpDefaultArgs        _mem, 666, NAN
 #   define d_usesMemory(mem)
+#   define d_usesFP()
+#   define d_saveFP()
 #   define d_updateMem(mem)         _mem = mem
 #   define m3MemData(mem)           (u8*)((M3MemoryHeader*)(mem)+1)
 typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig);
@@ -30,15 +32,54 @@ typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig);
 // In total they occupy the max. number of registers which can be used for function arguments on Xtensa
 // Any extra args would have to go onto the stack.
 // Unlike the !d_m3NoTailCalls case above, _mem becomes a global (but can be made thread local if needed).
-#   define d_m3OpSig                pc_t _pc, u64 * _sp, m3reg_t _r0, f64 _fp0
-#   define d_m3OpArgs               _sp, _r0, _fp0
-#   define d_m3OpAllArgs            _pc, _sp, _r0, _fp0
-#   define d_m3OpDefaultArgs        666, NAN
+#   define d_m3OpSig                pc_t _pc, u64 * _sp, m3reg_t _r0
+#   define d_m3OpArgs               _sp, _r0
+#   define d_m3OpAllArgs            _pc, _sp, _r0
+#   define d_m3OpDefaultArgs        666
 
 #   define m3MemData(mem)           (u8*)((M3MemoryHeader*)(mem)+1)
 extern M3MemoryHeader * g_mem;
 #   define d_usesMemory(mem)       M3MemoryHeader * mem = g_mem;
 #   define d_updateMem(mem)        g_mem = mem
+
+#ifdef __xtensa__
+
+#   define d_usesFP()              f64 _fp0 __attribute__((unused)) = loadFP()
+#   define d_saveFP()              saveFP(_fp0)
+
+static inline f64 loadFP() {
+    union {
+        f64 fp;
+        struct {
+            u32 l;
+            u32 h;
+        };
+    } res;
+    __asm__ __volatile__("rur.F64R_LO %0":"=r"(res.l));
+    __asm__  __volatile__("rur.F64R_HI %0":"=r"(res.h));
+    return res.fp;
+}
+
+static inline void saveFP(f64 fp) {
+    union {
+        f64 fp;
+        struct {
+            u32 l;
+            u32 h;
+        };
+    } arg;
+    arg.fp = fp;
+    __asm__  __volatile__("wur.F64R_LO %0"::"r"(arg.l));
+    __asm__  __volatile__("wur.F64R_HI %0"::"r"(arg.h));
+}
+#else // __xtensa___
+
+extern f64 g_fp0;
+
+#   define d_usesFP()              f64 _fp0 __attribute__((unused)) = g_fp0
+#   define d_saveFP()              g_fp0 = _fp0
+
+#endif // __xtensa__
 
 typedef struct {
     union {
@@ -47,11 +88,10 @@ typedef struct {
     };
     m3stack_t sp;
     m3reg_t r0;
-    f64 fp0;
 } m3_ret_struct_t;
 
-#define d_m3OpRetError(e)  return (m3_ret_struct_t) {.err=e, .sp=0, .r0 = 0, .fp0 = 0}
-#define d_m3OpRetTailCall(pc_)  return (m3_ret_struct_t) {.pc=pc_, .sp=_sp, .r0 = _r0, .fp0 = _fp0}
+#define d_m3OpRetError(e)  return (m3_ret_struct_t) {.err=e, .sp=0, .r0 = 0}
+#define d_m3OpRetTailCall(pc_)  return (m3_ret_struct_t) {.pc=pc_, .sp=_sp, .r0 = _r0}
 typedef m3_ret_struct_t (vectorcall * IM3Operation) (d_m3OpSig);
 
 #endif // d_m3NoTailCalls

--- a/source/m3_math_utils.h
+++ b/source/m3_math_utils.h
@@ -81,7 +81,7 @@ int __builtin_clzll(uint64_t value) {
 
 
 // TODO: not sure why, signbit is actually defined in math.h
-#if defined(ESP8266) || defined(ESP32)
+#if (defined(ESP8266) || defined(ESP32)) && !defined(signbit)
     #define signbit(__x) \
             ((sizeof(__x) == sizeof(float))  ?  __signbitf(__x) : __signbitd(__x))
 #endif

--- a/source/m3_math_utils.h
+++ b/source/m3_math_utils.h
@@ -155,25 +155,25 @@ u64 rotr64(u64 n, unsigned c) {
  */
 
 #define OP_DIV_U(RES, A, B)                                  \
-    if (UNLIKELY(B == 0)) return m3Err_trapDivisionByZero;   \
+    if (UNLIKELY(B == 0)) returnError(m3Err_trapDivisionByZero);   \
     RES = A / B;
 
 #define OP_REM_U(RES, A, B)                                  \
-    if (UNLIKELY(B == 0)) return m3Err_trapDivisionByZero;   \
+    if (UNLIKELY(B == 0)) returnError(m3Err_trapDivisionByZero);   \
     RES = A % B;
 
 // 2's complement detection
 #if (INT_MIN != -INT_MAX)
 
     #define OP_DIV_S(RES, A, B, TYPE_MIN)                        \
-        if (UNLIKELY(B == 0)) return m3Err_trapDivisionByZero;   \
+        if (UNLIKELY(B == 0)) returnError(m3Err_trapDivisionByZero);   \
         if (UNLIKELY(B == -1 and A == TYPE_MIN)) {               \
-            return m3Err_trapIntegerOverflow;                    \
+            returnError(m3Err_trapIntegerOverflow);                    \
         }                                                        \
         RES = A / B;
 
     #define OP_REM_S(RES, A, B, TYPE_MIN)                        \
-        if (UNLIKELY(B == 0)) return m3Err_trapDivisionByZero;   \
+        if (UNLIKELY(B == 0)) returnError(m3Err_trapDivisionByZero);   \
         if (UNLIKELY(B == -1 and A == TYPE_MIN)) RES = 0;        \
         else RES = A % B;
 
@@ -190,10 +190,10 @@ u64 rotr64(u64 n, unsigned c) {
 
 #define OP_TRUNC(RES, A, TYPE, RMIN, RMAX)                  \
     if (UNLIKELY(isnan(A))) {                               \
-        return m3Err_trapIntegerConversion;                 \
+        returnError(m3Err_trapIntegerConversion);                 \
     }                                                       \
     if (UNLIKELY(A <= RMIN or A >= RMAX)) {                 \
-        return m3Err_trapIntegerOverflow;                   \
+        returnError(m3Err_trapIntegerOverflow);                   \
     }                                                       \
     RES = (TYPE)A;
 

--- a/source/m3_xtensa.S
+++ b/source/m3_xtensa.S
@@ -1,0 +1,26 @@
+
+    .global     runOp
+    .type       runOp,@function
+    .align      4
+
+/* m3ret_t runOp(pc_t _pc, u64 * _sp, m3reg_t _r0) */
+runOp:
+
+    entry sp, 16
+    /* Incoming arguments: a2: _pc, a3: _sp, a4-a5: _r0 */
+
+    /* Outgoing arguments (for call8): a6: _pc, a7: _sp, a8-a9: _r0 */
+    mov a9, a5
+    mov a8, a4
+    mov a7, a3
+    mov a6, a2
+
+1:
+    l32i a2, a6, 0
+    addi a6, a6, 4
+    callx4 a2
+    bnez a7, 1b
+
+    /* Set return value */
+    or a2, a6, a6
+    retw


### PR DESCRIPTION
As pointed out in https://github.com/wasm3/wasm3/issues/28#issuecomment-569831125, Xtensa port suffers from lack of tail call optimization in the compiler. Tail calls are possible on the ESP8266 (but not implemented in GCC) and aren't possible on the ESP32, due to the ABI limitation.

This PR aims to provide an alternative to tail calls as means of chaining primitive operations.

The idea is to modify the operation function signature as follows:

```c++
m3_ret_struct_t OP(pc_t _pc, u64 * _sp, m3reg_t _r0, f64 _fp0);
```

where return structure `m3_ret_struct_t` has the same layout (in registers) as the input arguments:

```c++
typedef struct {
    union {
        pc_t pc;
        m3ret_t err;
    };
    m3stack_t sp;
    m3reg_t r0;
    f64 fp0;
} m3_ret_struct_t;
```

No tail calls are performed, instead all the operations are called from the following loop:

```c++
    while (true) {
        m3_ret_struct_t rs = ((IM3Operation) *_pc)(_pc+1, _sp, _r0, _fp0);
        _pc = rs.pc;
        _sp = rs.sp;
        _r0 = rs.r0;
        _fp0 = rs.fp0;
        if (_sp == NULL) {
            return rs.err;
        }
    }
```

Zero/non-zero `_sp` is used to indicate whether execution should be continued (operation wants a tail call) or the loop should return (operation wants to return).

The theory (which I haven't tested yet) is that the C loop above can be implemented in a few assembly instructions. This is because the return values after function call are already in the right registers. So we only need to check if `_sp` is zero, increment the PC, and jump to the PC again.

At the moment this modification seems to pass the spec tests.

Another change is converting `_mem` into a global value. This is needed to make the operation arguments fit into the registers, as on Xtensa only 6 32-bit registers are used for argument passing. The rest of the arguments would have to be spilled onto the stack. If necessary, `_mem` can be made thread-local instead of global.