### PR TITLE
[optimize] Use branchless clz / ctz for x86 (before AVX2 on Intel & ABM+BMI1 on AMD)

### DIFF
--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -239,7 +239,7 @@ d_m3UnaryOp_i (i32, EqualToZero, OP_EQZ)
 d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 
 // clz(0), ctz(0) results are undefined, fix it
-#if defined(__i386__) || defined(__x86_64__)
+#if (defined(__i386__) || defined(__x86_64__)) && !defined(__AVX2__)
     #define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
     #define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
     #define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -239,7 +239,7 @@ d_m3UnaryOp_i (i32, EqualToZero, OP_EQZ)
 d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 
 // clz(0), ctz(0) results are undefined, fix it
-#if (defined(__i386__) || defined(__x86_64__)) && !defined(__AVX2__)
+#if (defined(__i386__) || defined(__x86_64__)) && (!defined(__AVX2__) || !(defined(__ABM__) || defined(__BMI__)))
     #define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
     #define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
     #define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -238,12 +238,19 @@ d_m3UnaryOp_f (f32, Negate,     -);             d_m3UnaryOp_f (f64, Negate,     
 d_m3UnaryOp_i (i32, EqualToZero, OP_EQZ)
 d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 
-// clz(0), ctz(0) results are undefined, fix it
+// clz(0), ctz(0) results are undefined for rest platforms, fix it
 #if (defined(__i386__) || defined(__x86_64__)) && !(defined(__AVX2__) || (defined(__ABM__) && defined(__BMI__)))
     #define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
     #define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
     #define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))
     #define OP_CTZ_64(x) (__builtin_ctzll((x) | (1LL << 63)) + OP_EQZ(x))
+#elif defined(__ppc__) || defined(__ppc64__)
+// PowerPC is defined for __builtin_clz(0) and __builtin_ctz(0).
+// See (https://github.com/aquynh/capstone/blob/master/MathExtras.h#L99)
+    #define OP_CLZ_32(x)   __builtin_clz(x)
+    #define OP_CTZ_32(x)   __builtin_ctz(x)
+    #define OP_CLZ_64(x) __builtin_clzll(x)
+    #define OP_CTZ_64(x) __builtin_ctzll(x)
 #else
     #define OP_CLZ_32(x) (((x) == 0) ? 32 : __builtin_clz(x))
     #define OP_CTZ_32(x) (((x) == 0) ? 32 : __builtin_ctz(x))

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -239,7 +239,7 @@ d_m3UnaryOp_i (i32, EqualToZero, OP_EQZ)
 d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 
 // clz(0), ctz(0) results are undefined, fix it
-#if (defined(__i386__) || defined(__x86_64__)) && (!defined(__AVX2__) || !(defined(__ABM__) || defined(__BMI__)))
+#if (defined(__i386__) || defined(__x86_64__)) && !(defined(__AVX2__) || (defined(__ABM__) && defined(__BMI__)))
     #define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
     #define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
     #define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -239,10 +239,10 @@ d_m3UnaryOp_i (i32, EqualToZero, OP_EQZ)
 d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 
 // clz(0), ctz(0) results are undefined, fix it
-#define OP_CLZ_32(x) (((x) == 0) ? 32 : __builtin_clz(x))
-#define OP_CTZ_32(x) (((x) == 0) ? 32 : __builtin_ctz(x))
-#define OP_CLZ_64(x) (((x) == 0) ? 64 : __builtin_clzll(x))
-#define OP_CTZ_64(x) (((x) == 0) ? 64 : __builtin_ctzll(x))
+#define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
+#define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
+#define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))
+#define OP_CTZ_64(x) (__builtin_ctzll((x) | (1LL << 63)) + OP_EQZ(x))
 
 d_m3UnaryOp_i (u32, Clz, OP_CLZ_32)
 d_m3UnaryOp_i (u64, Clz, OP_CLZ_64)

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -248,8 +248,8 @@ d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 #elif defined(__ppc__) || defined(__ppc64__)
 // PowerPC is defined for __builtin_clz(0) and __builtin_ctz(0).
 // See (https://github.com/aquynh/capstone/blob/master/MathExtras.h#L99)
-    #define OP_CLZ_32(x)   __builtin_clz(x)
-    #define OP_CTZ_32(x)   __builtin_ctz(x)
+    #define OP_CLZ_32(x) __builtin_clz(x)
+    #define OP_CTZ_32(x) __builtin_ctz(x)
     #define OP_CLZ_64(x) __builtin_clzll(x)
     #define OP_CTZ_64(x) __builtin_ctzll(x)
 #else

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -239,10 +239,17 @@ d_m3UnaryOp_i (i32, EqualToZero, OP_EQZ)
 d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 
 // clz(0), ctz(0) results are undefined, fix it
-#define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
-#define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
-#define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))
-#define OP_CTZ_64(x) (__builtin_ctzll((x) | (1LL << 63)) + OP_EQZ(x))
+#if defined(__i386__) || defined(__x86_64__)
+    #define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
+    #define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
+    #define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))
+    #define OP_CTZ_64(x) (__builtin_ctzll((x) | (1LL << 63)) + OP_EQZ(x))
+#else
+    #define OP_CLZ_32(x) (((x) == 0) ? 32 : __builtin_clz(x))
+    #define OP_CTZ_32(x) (((x) == 0) ? 32 : __builtin_ctz(x))
+    #define OP_CLZ_64(x) (((x) == 0) ? 64 : __builtin_clzll(x))
+    #define OP_CTZ_64(x) (((x) == 0) ? 64 : __builtin_ctzll(x))
+#endif
 
 d_m3UnaryOp_i (u32, Clz, OP_CLZ_32)
 d_m3UnaryOp_i (u64, Clz, OP_CLZ_64)

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -240,8 +240,9 @@ d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
 
 // clz(0), ctz(0) results are undefined for rest platforms, fix it
 #if (defined(__i386__) || defined(__x86_64__)) && !(defined(__AVX2__) || (defined(__ABM__) && defined(__BMI__)))
-    #define OP_CLZ_32(x)   (__builtin_clz((x) | (1   <<  0)) + OP_EQZ(x))
-    #define OP_CTZ_32(x)   (__builtin_ctz((x) | (1   << 31)) + OP_EQZ(x))
+    #define OP_CLZ_32(x) (OP_EQZ(x) ? 32 : __builtin_clz(x))
+    #define OP_CTZ_32(x) (OP_EQZ(x) ? 32 : __builtin_ctz(x))
+    // for 64-bit instructions branchless approach more preferable
     #define OP_CLZ_64(x) (__builtin_clzll((x) | (1LL <<  0)) + OP_EQZ(x))
     #define OP_CTZ_64(x) (__builtin_ctzll((x) | (1LL << 63)) + OP_EQZ(x))
 #elif defined(__ppc__) || defined(__ppc64__)
@@ -252,10 +253,10 @@ d_m3UnaryOp_i (i64, EqualToZero, OP_EQZ)
     #define OP_CLZ_64(x) __builtin_clzll(x)
     #define OP_CTZ_64(x) __builtin_ctzll(x)
 #else
-    #define OP_CLZ_32(x) (((x) == 0) ? 32 : __builtin_clz(x))
-    #define OP_CTZ_32(x) (((x) == 0) ? 32 : __builtin_ctz(x))
-    #define OP_CLZ_64(x) (((x) == 0) ? 64 : __builtin_clzll(x))
-    #define OP_CTZ_64(x) (((x) == 0) ? 64 : __builtin_ctzll(x))
+    #define OP_CLZ_32(x) (OP_EQZ(x) ? 32 : __builtin_clz(x))
+    #define OP_CTZ_32(x) (OP_EQZ(x) ? 32 : __builtin_ctz(x))
+    #define OP_CLZ_64(x) (OP_EQZ(x) ? 64 : __builtin_clzll(x))
+    #define OP_CTZ_64(x) (OP_EQZ(x) ? 64 : __builtin_ctzll(x))
 #endif
 
 d_m3UnaryOp_i (u32, Clz, OP_CLZ_32)


### PR DESCRIPTION
Compare approaches her:
https://godbolt.org/z/URTGNG