### PR TITLE
Minor ESP32 fixes

### DIFF
--- a/docs/Performance.md
+++ b/docs/Performance.md
@@ -58,8 +58,8 @@ OpenWRT                                      3m 20s
 ----------------------------------------------------------------------------------------------------
 Maix (K210)        rv64imafc @ 400MHz          77ms        77ms
 ESP8266                LX106 @ 160MHz         308ms       321ms      TCO failed,   stack used: 9024
-ESP32                    LX6 @ 240MHz         340ms       350ms      TCO failed,   stack used: 10600
-ESP32-s2 (beta)          LX6 @ 240MHz         340ms       351ms      TCO failed
+ESP32                    LX6 @ 240MHz         297ms       314ms      TCO failed,   stack used: 10600
+ESP32-s2 (beta)          LX6 @ 240MHz         297ms       314ms      TCO failed
 Particle Photon       Arm M3 @ 120MHz         536ms       562ms
 MXChip AZ3166         Arm M4 @ 100MHz            ms          ms
 WM W600               Arm M3 @ 80MHz          698ms       782ms      TCO enabled,  stack used: 1325

--- a/platforms/esp32-idf/main/CMakeLists.txt
+++ b/platforms/esp32-idf/main/CMakeLists.txt
@@ -23,4 +23,4 @@ else()
     target_link_libraries(${COMPONENT_TARGET} PRIVATE m3)
 endif()
 
-target_compile_options(m3 PUBLIC -DM3_IN_IRAM -DESP32 -Dd_m3LogOutput=false)
+target_compile_options(m3 PUBLIC -DM3_IN_IRAM -DESP32 -Dd_m3LogOutput=false -O3 -freorder-blocks)

--- a/platforms/esp32-idf/sdkconfig.defaults
+++ b/platforms/esp32-idf/sdkconfig.defaults
@@ -4,5 +4,5 @@ CONFIG_ESP_MAIN_TASK_STACK_SIZE=32768
 # Disable task watchdog
 CONFIG_ESP_TASK_WDT=n
 
-# Increse CPU frequency
+# Increase CPU frequency
 CONFIG_ESP32_DEFAULT_CPU_FREQ_240=y

--- a/source/m3_math_utils.h
+++ b/source/m3_math_utils.h
@@ -81,7 +81,7 @@ int __builtin_clzll(uint64_t value) {
 
 
 // TODO: not sure why, signbit is actually defined in math.h
-#if defined(ESP8266) || defined(ESP32)
+#if (defined(ESP8266) || defined(ESP32)) && !defined(signbit)
     #define signbit(__x) \
             ((sizeof(__x) == sizeof(float))  ?  __signbitf(__x) : __signbitd(__x))
 #endif


### PR DESCRIPTION
- Fix warning about `signbit` redefined (happens with the newer toolchain releases in IDF 4.1 and later)
- platforms/esp32: optimize WASM3 source for performance, update the benchmark table.