### PR TITLE
allow for dynamic callbacks

### DIFF
--- a/source/m3_exec.c
+++ b/source/m3_exec.c
@@ -120,6 +120,16 @@ d_m3OpDef  (CallRawFunction)
     return possible_trap;
 }
 
+d_m3OpDef  (CallRawFunctionEx)
+{
+    M3RawCallEx call = (M3RawCallEx) (* _pc++);
+    void * cookie = immediate (void *);
+    IM3Runtime runtime = GetRuntime (_mem);
+
+    m3ret_t possible_trap = call (runtime, _sp, m3MemData(_mem), cookie);
+    return possible_trap;
+}
+
 
 d_m3OpDef  (MemCurrent)
 {

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -606,6 +606,7 @@ d_m3OpDecl  (Compile)
 d_m3OpDecl  (Call)
 d_m3OpDecl  (CallIndirect)
 d_m3OpDecl  (CallRawFunction)
+d_m3OpDecl  (CallRawFunctionEx)
 d_m3OpDecl  (Entry)
 
 d_m3OpDecl  (MemCurrent)

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -208,6 +208,17 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
                                                      const char * const     i_signature,
                                                      M3RawCall              i_function);
 
+    typedef const void * (* M3RawCallEx) (IM3Runtime runtime, uint64_t * _sp, void * _mem, void * cookie);
+
+    // m3_LinkRawFunctionEx links a native callback function that has a cookie parameter, allowing one native
+    // callback to receive multiple m3 function calls. This ease for dynamic routing in the callback.
+    M3Result            m3_LinkRawFunctionEx        (IM3Module              io_module,
+                                                     const char * const     i_moduleName,
+                                                     const char * const     i_functionName,
+                                                     const char * const     i_signature,
+                                                     M3RawCallEx            i_function,
+                                                     void *                 i_cookie);
+
 //-------------------------------------------------------------------------------------------------------------------------------
 //  functions
 //-------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR allows a client code to register native function as callback.

There was already a mecanism to do that, but the callback signature did not have any information beyond the M3 normal context (runtime, sp and mem).

The extended mecanism allows the client to specify a uin64 cookie value that will be given to the native callback when called.

This is useful because if you want to register hundreds of callbacks, with the previous mecanism you had to define hundreds of callback functions, this was not scaling.