### PR TITLE
Fix several memory leaks

### DIFF
--- a/source/m3_core.h
+++ b/source/m3_core.h
@@ -165,7 +165,7 @@ static const char * const c_waCompactTypes []   = { "0", "i", "I", "f", "F", "v"
 
 
 #define m3Alloc(OPTR, STRUCT, NUM)              m3Malloc ((void **) OPTR, sizeof (STRUCT) * (NUM))
-#define m3RellocArray(PTR, STRUCT, NEW, OLD)    m3Realloc ((PTR), sizeof (STRUCT) * (NEW), sizeof (STRUCT) * (OLD))
+#define m3ReallocArray(PTR, STRUCT, NEW, OLD)   m3Realloc ((PTR), sizeof (STRUCT) * (NEW), sizeof (STRUCT) * (OLD))
 #define m3Free(P)                               { m3Free_impl((void*)(P)); P = NULL; }
 
 # if d_m3VerboseLogs

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -422,7 +422,7 @@ _           (ReadLEB_u32 (& numElements, & bytes, end));
 
             if (endElement > offset) // TODO: check this, endElement depends on offset
             {
-                io_module->table0 = (IM3Function*)m3RellocArray (io_module->table0, IM3Function, endElement, io_module->table0Size);
+                io_module->table0 = (IM3Function*)m3ReallocArray (io_module->table0, IM3Function, endElement, io_module->table0Size);
 
                 if (io_module->table0)
                 {

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -175,6 +175,8 @@ void  ReleaseRuntime  (IM3Runtime i_runtime)
     FreeCompilationPatches (& i_runtime->compilation);
 
     m3Free (i_runtime->stack);
+
+    m3Free (i_runtime->memory.mallocated);
 }
 
 

--- a/source/m3_module.c
+++ b/source/m3_module.c
@@ -33,7 +33,7 @@ M3Result  Module_AddGlobal  (IM3Module io_module, IM3Global * o_global, u8 i_typ
     M3Result result = m3Err_none;
 
     u32 index = io_module->numGlobals++;
-    io_module->globals = (M3Global *) m3RellocArray (io_module->globals, M3Global, io_module->numGlobals, index);
+    io_module->globals = (M3Global *) m3ReallocArray (io_module->globals, M3Global, io_module->numGlobals, index);
 
     if (io_module->globals)
     {
@@ -57,7 +57,7 @@ M3Result  Module_AddFunction  (IM3Module io_module, u32 i_typeIndex, IM3ImportIn
     M3Result result = m3Err_none;
 
     u32 index = io_module->numFunctions++;
-    io_module->functions = (M3Function*)m3RellocArray (io_module->functions, M3Function, io_module->numFunctions, index);
+    io_module->functions = (M3Function*)m3ReallocArray (io_module->functions, M3Function, io_module->numFunctions, index);
 
     if (io_module->functions)
     {

--- a/source/m3_module.c
+++ b/source/m3_module.c
@@ -8,6 +8,8 @@
 
 #include "m3_env.h"
 
+static void Module_FreeFunctions(IM3Module i_module);
+
 void  m3_FreeModule  (IM3Module i_module)
 {
     if (i_module)
@@ -15,10 +17,13 @@ void  m3_FreeModule  (IM3Module i_module)
         m3log (module, "freeing module: %s (funcs: %d; segments: %d)",
                i_module->name, i_module->numFunctions, i_module->numDataSegments);
 
+        Module_FreeFunctions (i_module);
+
         m3Free (i_module->functions);
         m3Free (i_module->imports);
         m3Free (i_module->funcTypes);
         m3Free (i_module->dataSegments);
+        m3Free (i_module->table0);
 
         // TODO: free importinfo
         m3Free (i_module->globals);
@@ -27,6 +32,20 @@ void  m3_FreeModule  (IM3Module i_module)
     }
 }
 
+static void Module_FreeFunctions(IM3Module i_module)
+{
+    for (u32 i = 0; i < i_module->numFunctions; ++i)
+    {
+        IM3Function func = &i_module->functions[i];
+        m3Free (func->constants);
+        if (func->name != func->import.fieldUtf8)
+        {
+            m3Free (func->name);
+        }
+
+        FreeImportInfo (&func->import);
+    }
+}
 
 M3Result  Module_AddGlobal  (IM3Module io_module, IM3Global * o_global, u8 i_type, bool i_mutable, bool i_isImported)
 {


### PR DESCRIPTION
Running the esp32-idf-wasi application in heap profiler has revealed a few memory leaks. This PR fixes the leaks.

A future TODO may be to run some tests in CI under valgrind.
