### PR TITLE
prefix min and max macros with m3_ to avoid conflicts with the STL

### DIFF
--- a/platforms/esp32-idf-wasi/main/m3_api_esp_wasi.c
+++ b/platforms/esp32-idf-wasi/main/m3_api_esp_wasi.c
@@ -181,7 +181,7 @@ m3ApiRawFunction(m3_wasi_unstable_fd_prestat_dir_name)
 
     if (runtime == NULL) { m3ApiReturn(__WASI_EINVAL); }
     if (fd < 3 || fd >= PREOPEN_CNT) { m3ApiReturn(__WASI_EBADF); }
-    int size = min(strlen(preopen[fd].path), path_len);
+    int size = M3_MIN(strlen(preopen[fd].path), path_len);
     memcpy(path, preopen[fd].path, size);
     m3ApiReturn(__WASI_ESUCCESS);
 }
@@ -355,7 +355,7 @@ m3ApiRawFunction(m3_wasi_unstable_random_get)
         ssize_t retlen = 0;
 
 #if defined(__wasi__) || defined(__APPLE__) || defined(__ANDROID_API__) || defined(__OpenBSD__)
-        size_t reqlen = min(buflen, 256);
+        size_t reqlen = M3_MIN(buflen, 256);
         if (getentropy(buf, reqlen) < 0) {
             retlen = -1;
         } else {

--- a/source/m3_api_wasi.c
+++ b/source/m3_api_wasi.c
@@ -250,7 +250,7 @@ m3ApiRawFunction(m3_wasi_unstable_fd_prestat_dir_name)
 
     if (runtime == NULL) { m3ApiReturn(__WASI_EINVAL); }
     if (fd < 3 || fd >= PREOPEN_CNT) { m3ApiReturn(__WASI_EBADF); }
-    int size = min(strlen(preopen[fd].path), path_len);
+    int size = M3_MIN(strlen(preopen[fd].path), path_len);
     memcpy(path, preopen[fd].path, size);
     m3ApiReturn(__WASI_ESUCCESS);
 }
@@ -543,7 +543,7 @@ m3ApiRawFunction(m3_wasi_unstable_random_get)
         ssize_t retlen = 0;
 
 #if defined(__wasi__) || defined(__APPLE__) || defined(__ANDROID_API__) || defined(__OpenBSD__)
-        size_t reqlen = min(buflen, 256);
+        size_t reqlen = M3_MIN(buflen, 256);
 #   if defined(__APPLE__) && (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
         retlen = SecRandomCopyBytes(kSecRandomDefault, reqlen, buf) < 0 ? -1 : reqlen;
 #   else

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -2048,7 +2048,7 @@ M3Result  Compile_ReserveConstants  (IM3Compilation o)
     // if constants overflow their reserved stack space, the compiler simply emits op_Const
     // operations as needed. Compiled expressions (global inits) don't pass through this
     // ReserveConstants function and thus always produce inline contants.
-    numConstants = min (numConstants, d_m3MaxNumFunctionConstants);
+    numConstants = M3_MIN (numConstants, d_m3MaxNumFunctionConstants);
 
     u32 freeSlots = d_m3MaxFunctionStackHeight - o->constSlotIndex;
 

--- a/source/m3_config_platforms.h
+++ b/source/m3_config_platforms.h
@@ -178,16 +178,11 @@
 #  define M3_WEAK __attribute__((weak))
 # endif
 
-/* Don't define min and max when compiling C++ sources;
- * this causes issues in STL where min() and max() member functions are defined.
- */
-# ifndef __cplusplus
-#  ifndef min
-#   define min(A,B) (((A) < (B)) ? (A) : (B))
-#  endif
-#  ifndef max
-#   define max(A,B) (((A) > (B)) ? (A) : (B))
-#  endif
+# ifndef M3_MIN
+#  define M3_MIN(A,B) (((A) < (B)) ? (A) : (B))
+# endif
+# ifndef M3_MAX
+#  define M3_MAX(A,B) (((A) > (B)) ? (A) : (B))
 # endif
 
 #define M3_INIT(field) memset(&field, 0, sizeof(field))

--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -173,7 +173,7 @@ void        m3StackCheck ()
     size_t addr = (size_t)&stack;
 
     size_t stackEnd = stack_end;
-    stack_end = min(stack_end, addr);
+    stack_end = M3_MIN(stack_end, addr);
 
 //    if (stackEnd != stack_end)
 //        printf ("maxStack: %ld\n", m3StackGetMax ());

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -296,7 +296,7 @@ M3Result  ResizeMemory  (IM3Runtime io_runtime, u32 i_numPages)
 
         // Limit the amount of memory that gets allocated
         if (io_runtime->memoryLimit) {
-            numPageBytes = min(numPageBytes, io_runtime->memoryLimit);
+            numPageBytes = M3_MIN(numPageBytes, io_runtime->memoryLimit);
         }
 
         size_t numBytes = numPageBytes + sizeof (M3MemoryHeader);

--- a/source/m3_info.c
+++ b/source/m3_info.c
@@ -92,7 +92,7 @@ size_t  SPrintArg  (char * o_string, size_t i_n, m3stack_t i_sp, u8 i_type)
     else if (i_type == c_m3Type_f64)
         len = snprintf (o_string, i_n, "%lf", * (f64 *) i_sp);
 
-    len = max (0, len);
+    len = M3_MAX (0, len);
 
     return len;
 }
@@ -105,7 +105,7 @@ cstr_t  SPrintFunctionArgList  (IM3Function i_function, m3stack_t i_sp)
     char * s = string;
     ccstr_t e = string + sizeof(string) - 1;
 
-    s += max (0, snprintf (s, e-s, "("));
+    s += M3_MAX (0, snprintf (s, e-s, "("));
 
     IM3FuncType funcType = i_function->funcType;
     if (funcType)
@@ -117,17 +117,17 @@ cstr_t  SPrintFunctionArgList  (IM3Function i_function, m3stack_t i_sp)
         {
             u8 type = types [i];
 
-            s += max (0, snprintf (s, e-s, "%s: ", c_waTypes [type]));
+            s += M3_MAX (0, snprintf (s, e-s, "%s: ", c_waTypes [type]));
 
             s += SPrintArg (s, e-s, i_sp + i, type);
 
             if (i != numArgs - 1)
-                s += max (0, snprintf (s, e-s, ", "));
+                s += M3_MAX (0, snprintf (s, e-s, ", "));
         }
     }
     else printf ("null signature");
 
-    s += max (0, snprintf (s, e-s, ")"));
+    s += M3_MAX (0, snprintf (s, e-s, ")"));
 
     return string;
 }


### PR DESCRIPTION
This reverts the change introduced in b087435, that made min/max
definitions conditional on !__cplusplus. Since some use cases of wasm3
require its C source files to be compiled with a C++ compiler, that
change resulted in min/max being undefined for WASMM3 source files.

This commit makes min/max macros scoped with m3_ prefix, which
resolves the conflict with min/max member functions defined in the STL
and elsewhere.

Closes https://github.com/wasm3/wasm3/issues/92