### PR TITLE
update link to WASM summit music talk

### DIFF
--- a/test/benchmark/wasmsynth/README.md
+++ b/test/benchmark/wasmsynth/README.md
@@ -9,7 +9,7 @@ Here is some music created by [Peter Salomonsen](https://petersalomonsen.com/) i
 - **Shuffle Chill**, `shuffle-chill.wasm` │ [SoundCloud](https://soundcloud.com/psalomo/shuffle-chill)
 - **"WebChip" music**, `webchip-music.wasm` │ [SoundCloud](https://soundcloud.com/psalomo/webchip-music)
 
-Check out Peter's [excellent talk on WebAssembly Summit 2020](https://www.youtube.com/watch?v=WZp0sPDvWfw&t=18670).
+Check out Peter's [excellent talk on WebAssembly Summit 2020](https://youtu.be/C8j_ieOm4vE).
 
 ### Running
 


### PR DESCRIPTION
Replacing with the new video from WebAssembly summit 2020 youtube channel.

Also see my reference to this page from my project:

https://github.com/petersalomonsen/javascriptmusic/tree/master/wasmaudioworklet#export-to-wasm-in-the-browser