### PR TITLE
Make m3_GetMemory non-const

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -989,7 +989,7 @@ M3StackInfo  m3_GetNativeStackInfo  (i32 i_stackSize)
     return info;
 }
 
-const uint8_t *  m3_GetMemory  (IM3Runtime i_runtime, uint32_t * o_memorySizeInBytes, uint32_t i_memoryIndex)
+uint8_t *  m3_GetMemory  (IM3Runtime i_runtime, uint32_t * o_memorySizeInBytes, uint32_t i_memoryIndex)
 {
     uint8_t * memory = NULL;
     d_m3Assert (i_memoryIndex == 0);

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -183,7 +183,7 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 
     void                m3_FreeRuntime              (IM3Runtime             i_runtime);
 
-    const uint8_t *     m3_GetMemory                (IM3Runtime             i_runtime,
+    uint8_t *           m3_GetMemory                (IM3Runtime             i_runtime,
                                                      uint32_t *             o_memorySizeInBytes,
                                                      uint32_t               i_memoryIndex);
     // Wasm currently only supports one memory region. i_memoryIndex should be zero.


### PR DESCRIPTION
Example use is here: https://github.com/wasmx/fizzy/blob/master/test/utils/wasm3_engine.cpp#L69

I'm not sure this is accepted upstream, but I am interested in feedback.