### PR TITLE
Introduce m3_CallProper

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -819,13 +819,12 @@ M3Result  m3_CallProper  (IM3Function i_function, uint32_t i_argc, const uint64_
 
         IM3FuncType ftype = i_function->funcType;
 
-        m3stack_t stack = (m3stack_t)(runtime->stack);
-
-        m3logif (runtime, PrintFuncTypeSignature (ftype));
-
         if (i_argc != ftype->numArgs) {
             _throw("arguments count mismatch");
         }
+
+        // args are always 64-bit aligned
+        u64 * stack = (u64 *) runtime->stack;
 
         // The format is currently not user-friendly by default,
         // as this is used in spec tests
@@ -843,7 +842,7 @@ M3Result  m3_CallProper  (IM3Function i_function, uint32_t i_argc, const uint64_
         }
 
         m3StackCheckInit();
-_       ((M3Result)Call (i_function->compiled, stack, runtime->memory.mallocated, d_m3OpDefaultArgs));
+_       ((M3Result) Call (i_function->compiled, (m3stack_t) stack, runtime->memory.mallocated, d_m3OpDefaultArgs));
 
         *o_valid = 1;
         switch (ftype->returnType) {

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -806,7 +806,7 @@ _       ((M3Result) Call (i_function->compiled, (m3stack_t) stack, runtime->memo
     _catch: return result;
 }
 
-M3Result  m3_CallProper  (IM3Function i_function, uint32_t i_argc, const uint64_t* i_argv, unsigned *o_valid, uint64_t* o_ret)
+M3Result  m3_CallProper  (IM3Function i_function, uint32_t i_argc, const uint64_t* i_argv, unsigned *o_hasRet, uint64_t* o_ret)
 {
     M3Result result = m3Err_none;
 
@@ -842,9 +842,9 @@ M3Result  m3_CallProper  (IM3Function i_function, uint32_t i_argc, const uint64_
         m3StackCheckInit();
 _       ((M3Result) Call (i_function->compiled, (m3stack_t) stack, runtime->memory.mallocated, d_m3OpDefaultArgs));
 
-        *o_valid = 1;
+        *o_hasRet = 1;
         switch (ftype->returnType) {
-        case c_m3Type_none: *o_valid = 0; break;
+        case c_m3Type_none: *o_hasRet = 0; break;
         case c_m3Type_i32: *o_ret = (uint64_t)(stack[0] & 0xffffffff); break;
         case c_m3Type_i64: *o_ret = (uint64_t)stack[0]; break;
         case c_m3Type_f32: *o_ret = (uint64_t)(stack[0] & 0xffffffff); break;

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -826,8 +826,6 @@ M3Result  m3_CallProper  (IM3Function i_function, uint32_t i_argc, const uint64_
         // args are always 64-bit aligned
         u64 * stack = (u64 *) runtime->stack;
 
-        // The format is currently not user-friendly by default,
-        // as this is used in spec tests
         for (u32 i = 0; i < ftype->numArgs; ++i)
         {
             stack[i] = i_argv[i];

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -847,7 +847,8 @@ _       ((M3Result) Call (i_function->compiled, (m3stack_t) stack, runtime->memo
         case c_m3Type_none: *o_hasRet = 0; break;
         case c_m3Type_i32: *o_ret = (uint64_t)(stack[0] & 0xffffffff); break;
         case c_m3Type_i64: *o_ret = (uint64_t)stack[0]; break;
-        case c_m3Type_f32: *o_ret = (uint64_t)(stack[0] & 0xffffffff); break;
+        // FIXME: not sure what happens with f32
+        case c_m3Type_f32: *o_ret = (uint64_t)stack[0]; break;
         case c_m3Type_f64: *o_ret = (uint64_t)stack[0]; break;
         default: _throw("unknown return type");
         }

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -848,10 +848,10 @@ _       ((M3Result)Call (i_function->compiled, stack, runtime->memory.mallocated
         *o_valid = 1;
         switch (ftype->returnType) {
         case c_m3Type_none: *o_valid = 0; break;
-        case c_m3Type_i32: *o_ret = *(i32*)(stack); break;
-        case c_m3Type_i64: *o_ret = *(i64*)(stack); break;
-        case c_m3Type_f32: *o_ret = *(f32*)(stack); break;
-        case c_m3Type_f64: *o_ret = *(f64*)(stack); break;
+        case c_m3Type_i32: *o_ret = (uint64_t)(stack[0] & 0xffffffff); break;
+        case c_m3Type_i64: *o_ret = (uint64_t)stack[0]; break;
+        case c_m3Type_f32: *o_ret = (uint64_t)(stack[0] & 0xffffffff); break;
+        case c_m3Type_f64: *o_ret = (uint64_t)stack[0]; break;
         default: _throw("unknown return type");
         }
     }

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -215,6 +215,8 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
     M3Result            m3_Call                     (IM3Function i_function);
     M3Result            m3_CallWithArgs             (IM3Function i_function, uint32_t i_argc, const char * const * i_argv);
 
+    M3Result            m3_CallProper               (IM3Function i_function, uint32_t i_argc, const uint64_t* i_argv, unsigned *o_valid, uint64_t* o_ret);
+
     // IM3Functions are valid during the lifetime of the originating runtime
 
     void                m3_GetErrorInfo             (IM3Runtime i_runtime, M3ErrorInfo* info);

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -215,7 +215,7 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
     M3Result            m3_Call                     (IM3Function i_function);
     M3Result            m3_CallWithArgs             (IM3Function i_function, uint32_t i_argc, const char * const * i_argv);
 
-    M3Result            m3_CallProper               (IM3Function i_function, uint32_t i_argc, const uint64_t* i_argv, unsigned *o_valid, uint64_t* o_ret);
+    M3Result            m3_CallProper               (IM3Function i_function, uint32_t i_argc, const uint64_t* i_argv, unsigned *o_hasRet, uint64_t* o_ret);
 
     // IM3Functions are valid during the lifetime of the originating runtime
 


### PR DESCRIPTION
I couldn't come up with a good name, but this is almost the same as `CallWithArgs` without string conversion.

I can rename it and squash commits, let me know.