### PR TITLE
update uvwasi to version 0.0.8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         - {target: gcc-debug,   cc: gcc,        flags: -DCMAKE_BUILD_TYPE=Debug   }
         # TODO: fails on numeric operations
         #- {target: gcc-x86,     cc: gcc,        flags: "-m32",                    install: "gcc-multilib"   }
- 
+
     steps:
     - uses: actions/checkout@v2
     - name: Install ${{ matrix.config.install }}
@@ -48,12 +48,12 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Prepare
-      run: apk add build-base cmake python3 --update-cache
+      run: apk add build-base cmake python3 git --update-cache
     - name: Configure
       run: |
         mkdir build
         cd build
-        cmake -DBUILD_WASI=simple ..    # TODO switch to uvwasi
+        cmake ..
     - name: Build
       run: cmake --build build
     - name: Test WebAssembly spec
@@ -275,7 +275,7 @@ jobs:
   build-platformio-arm:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -306,7 +306,7 @@ jobs:
   build-platformio-riscv:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
@@ -444,7 +444,7 @@ jobs:
     name: maintenance (preprocess ops)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    
+
     steps:
     - uses: actions/checkout@v2
     - name: Install sponge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ elseif(BUILD_WASI MATCHES "uvwasi")
   FetchContent_Declare(
     uvwasi
     GIT_REPOSITORY https://github.com/cjihrig/uvwasi.git
-    GIT_TAG ${v0.0.7}
+    GIT_TAG v0.0.8
   )
 
   FetchContent_GetProperties(uvwasi)

--- a/test/run-wasi-test.py
+++ b/test/run-wasi-test.py
@@ -40,8 +40,8 @@ commands_full = [
   }, {
     "name":           "Simple WASI test (wasm-opt -O3)",
     "wasm":           "./wasi/test-opt.wasm",
-    "args":           ["cat", "/wasi/0.txt"],
-    "expect_pattern": "Hello world*Constructor OK*Args: *; cat; /wasi/0.txt;*fib(20) = 6765*[* ms]*48 65 6c 6c 6f 20 77 6f 72 6c 64*=== done ===*"
+    "args":           ["cat", "./wasi/0.txt"],
+    "expect_pattern": "Hello world*Constructor OK*Args: *; cat; ./wasi/0.txt;*fib(20) = 6765*[* ms]*48 65 6c 6c 6f 20 77 6f 72 6c 64*=== done ===*"
   }, {
     "skip":           True,  # Direct native calls were removed from wasm3
     "name":           "Raw/Native funcs benchmark",


### PR DESCRIPTION
This release focuses on improving the robustness of the path resolution and sandboxing, including support for relative preopen paths.

This addresses https://github.com/wasm3/wasm3/pull/126#issuecomment-618095571.