### PR TITLE
Fix for emscripten_lib build

### DIFF
--- a/source/m3_api_uvwasi.c
+++ b/source/m3_api_uvwasi.c
@@ -15,7 +15,9 @@
 
 #if defined(d_m3HasUVWASI)
 
+#ifndef __EMSCRIPTEN__
 typedef uint32_t __wasi_size_t;
+#endif
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Fix for building for `EMSCRIPTEN_LIB`
- `__wasi_size_t` is found to be defined already so no need to redeclare it again ...