### PR TITLE
Implement InitStartFunc without m3_Call and ensure the correct function type

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -638,7 +638,14 @@ M3Result  InitStartFunc  (IM3Module io_module)
 _           (Compile_Function (function));
         }
 
-_       (m3_Call(function));
+        IM3FuncType ftype = function->funcType;
+        if (ftype->numArgs != 0 || ftype->returnType != c_m3Type_none)
+            _throw (m3Err_argumentCountMismatch);
+
+        IM3Module module = function->module;
+        IM3Runtime runtime = module->runtime;
+
+_       ((M3Result) Call (function->compiled, (m3stack_t) runtime->stack, runtime->memory.mallocated, d_m3OpDefaultArgs));
     }
 
     _catch: return result;


### PR DESCRIPTION
I was running some benchmarking with a wasm blob which uses a start function (compiled with AssemblyScript) and noticed I get a bunch of `Result: <Empty Stack>` messages. It seemed that can only be emitted in `m3_CallWithArgs`, a function I do not use, and while tracking down how the start function is handled in wasm3 I realised it goes through `m3_CallWithArgs`.

This PR removes that dependency on the external API and comes with a benefit: it ensures the proper type for the start function. `master` only checks that start takes no arguments, but doesn't validate that it it should not return anything.