### PR TITLE
Problem: not all compilers support C11 well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,7 @@ message("Build Type: ${CMAKE_BUILD_TYPE}")
 
 include(CheckIPOSupported)
 
-set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
 set(CMAKE_C_STANDARD_REQUIRED YES)
 set(CMAKE_C_EXTENSIONS NO)
 


### PR DESCRIPTION
wasm3 declares C11 as a requirement.

Solution: use C99 (a better support standard) instead
as the soruce code compiles and the tests seem to pass after compiling
using C99 as a standard.

---

Or was there a particular reason why C11 was chosen as a baseline? 