### PR TITLE
update uvwasi to version 0.0.11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,7 @@ elseif(BUILD_WASI MATCHES "uvwasi")
   FetchContent_Declare(
     uvwasi
     GIT_REPOSITORY https://github.com/cjihrig/uvwasi.git
-    GIT_TAG v0.0.9
+    GIT_TAG v0.0.11
   )
 
   FetchContent_GetProperties(uvwasi)

--- a/source/m3_api_uvwasi.c
+++ b/source/m3_api_uvwasi.c
@@ -470,17 +470,11 @@ M3Result  m3_LinkWASI  (IM3Module module)
     preopens[1].real_path = ".";
 
     uvwasi_options_t init_options;
-    memset(&init_options, 0, sizeof(uvwasi_options_t));
-    init_options.in  = 0;
-    init_options.out = 1;
-    init_options.err = 2;
-    init_options.fd_table_size = 3;
+    uvwasi_options_init(&init_options);
     init_options.argc = 0;      // runtime->argc is not initialized at this point, so we implement args_get directly
-    init_options.argv = NULL;
     init_options.envp = (const char **) env;
     init_options.preopenc = PREOPENS_COUNT;
     init_options.preopens = preopens;
-    init_options.allocator = NULL;
 
     uvwasi_errno_t ret = uvwasi_init(&uvwasi, &init_options);
 


### PR DESCRIPTION
Notable changes:

- The `uvwasi_preopen_t` now uses `const char*` for the `mapped_path` and `real_path` fields. Previously, these were not `const`.
- `uvwasi_path_filestat_get()` now properly handles the `UVWASI_LOOKUP_SYMLINK_FOLLOW` flag.
- `uvwasi_options_init()` has been added to reduce the boilerplate code associated with initializing `uvwasi_options_t`'s.
- The `DEBUG()` macro has been renamed to `UVWASI_DEBUG()` to reduce naming conflicts with other projects.
- The `uvwasi_fd_filestat_set_times()` and `uvwasi_path_filestat_set_times()` functions now have proper implementations.
- Several issues have been addressed in `uvwasi_fd_readdir()`. A bug in the copying of the directory entry's name has been fixed. The function now returns `UVWASI_ENOSYS` on Windows and Android. Serdes support has been added for `uvwasi_dirent_t`'s.
- The libuv dependency has been updated to v1.39.0.