### PR TITLE
Fix check for data count section ordering

### DIFF
--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -549,10 +549,10 @@ _   (Read_u32 (& version, & pos, end));
         u8 section;
 _       (ReadLEB_u7 (& section, & pos, end));
 
-        if (section > previousSection or            // from the spec: sections must appear in order
-            section == 0 or                         // custom section
-            (section == 12 and section == 9) or     // if present, DataCount goes after Element
-            (section == 10 and section == 12))      // and before Code
+        if (section > previousSection or                    // from the spec: sections must appear in order
+            section == 0 or                                 // custom section
+            (section == 12 and previousSection == 9) or     // if present, DataCount goes after Element
+            (section == 10 and previousSection == 12))      // and before Code
         {
             u32 sectionLength;
 _           (ReadLEB_u32 (& sectionLength, & pos, end));


### PR DESCRIPTION
I noticed what looked to me like a copy-pasta error when perusing through the code. Specifically, around the check for the position of the data count section which has an ID of 12 but comes before the code section.

As a side note the `section == 12 and previousSection == 9` check is not strictly necessary since `(section = 12) > (previousSection = 9)`, but it is informative so I left it in.