### PR TITLE
Add user pointer to Runtime, repurpose 'unused' param

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -276,7 +276,7 @@ void  Environment_ReleaseCodePages  (IM3Environment i_environment, IM3CodePage i
 }
 
 
-IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes, void * unused)
+IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes, void * i_userPointer)
 {
     IM3Runtime runtime = NULL;
     m3Alloc (& runtime, M3Runtime, 1);
@@ -286,6 +286,7 @@ IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes
         m3_ResetErrorInfo(runtime);
 
         runtime->environment = i_environment;
+        runtime->userPointer = i_userPointer;
 
         m3Alloc (& runtime->stack, u8, i_stackSizeInBytes);
 

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -250,6 +250,8 @@ typedef struct M3Runtime
     char                    error_message[256];
 #endif
     i32                     exit_code;
+
+    void*                   userPointer;
 }
 M3Runtime;
 

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -159,7 +159,7 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 
     IM3Runtime          m3_NewRuntime               (IM3Environment         io_environment,
                                                      uint32_t               i_stackSizeInBytes,
-                                                     void *                 unused);
+                                                     void *                 i_userPointer);
 
     void                m3_FreeRuntime              (IM3Runtime             i_runtime);
 


### PR DESCRIPTION
Hi, this is a very simple change that enable the user to associate a pointer to the M3Runtime object. This is useful on the common use case where you need to associate some data to the runtime and retreive it in the body of a linked function where you only gets the Runtime.

I reused the "unused" param on the newRuntime function since it was actually unused (probably it was first added with this functionality in mind). So this changes doesn't break the interface.