### PR TITLE
update uvwasi repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ elseif(BUILD_WASI MATCHES "uvwasi")
   include(FetchContent)
   FetchContent_Declare(
     uvwasi
-    GIT_REPOSITORY https://github.com/cjihrig/uvwasi.git
+    GIT_REPOSITORY https://github.com/nodejs/uvwasi.git
     GIT_TAG v0.0.11
   )
 


### PR DESCRIPTION
uvwasi was transferred into the Node.js GitHub org.
This commit updates the repository's link.