### PR TITLE
Fix Wasm3 Cosmopolitan build config

### DIFF
--- a/platforms/cosmopolitan/build.sh
+++ b/platforms/cosmopolitan/build.sh
@@ -25,9 +25,10 @@ fi
 
 echo "Building Wasm3..."
 
-gcc -g -O -static -fno-pie -no-pie -mno-red-zone -nostdlib -nostdinc                    \
-  -Wl,--oformat=binary -Wl,--gc-sections -Wl,-z,max-page-size=0x1000 -fuse-ld=bfd       \
-  -Wl,-T,cosmopolitan/ape.lds -include cosmopolitan/cosmopolitan.h                      \
-  -Wno-format-security -Wfatal-errors $EXTRA_FLAGS                                      \
-  -o wasm3.com -DAPE -I$STD -I$SOURCE_DIR $SOURCE_DIR/*.c ../app/main.c                 \
+gcc -g -O -static -fno-pie -no-pie -mno-red-zone -nostdlib -nostdinc           \
+  -Wl,--gc-sections -Wl,-z,max-page-size=0x1000 -fuse-ld=bfd                   \
+  -Wl,-T,cosmopolitan/ape.lds -include cosmopolitan/cosmopolitan.h             \
+  -Wno-format-security -Wfatal-errors $EXTRA_FLAGS                             \
+  -o wasm3.com.dbg -DAPE -I$STD -I$SOURCE_DIR $SOURCE_DIR/*.c ../app/main.c    \
   cosmopolitan/crt.o cosmopolitan/ape.o cosmopolitan/cosmopolitan.a
+objcopy -SO binary wasm3.com.dbg wasm3.com


### PR DESCRIPTION
@vshymanskyy per our discussion at https://github.com/jart/cosmopolitan/issues/32 here's a small change that might solve your build issue. It's not clear to me yet why this causes the cryptic linker error to go away. It is however a best practice in general to do this, since you'll want the debug info. Please let me know if this change resolves things on your end.