### PR TITLE
Fix off-by-one error in ParseSection_Export()

### DIFF
--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -229,7 +229,7 @@ _       (ReadLEB_u32 (& index, & i_bytes, i_end));                              
         {
             _throwif(m3Err_wasmMalformed, index >= io_module->numFunctions);
             u16 numNames = io_module->functions [index].numNames;
-            if (numNames < d_m3MaxDuplicateFunctionImpl - 1)
+            if (numNames < d_m3MaxDuplicateFunctionImpl)
             {
                 io_module->functions [index].numNames++;
                 io_module->functions [index].names[numNames] = utf8;


### PR DESCRIPTION
#198 contained a bug in which one fewer function name than `d_m3MaxDuplicateFunctionImpl` could be saved for a given function implementation. I caught this when preparing the [WebAssembly spec test pull request](https://github.com/WebAssembly/spec/pull/1289).

Arithmetic is hard. Sorry.