### PR TITLE
Python: Drop EOL Py35 and fix flake8 --select=E7 issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -543,7 +543,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ "3.5", "3.6", "3.7", "3.8", "3.9" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9" ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -559,6 +559,10 @@ jobs:
     - name: Install WABT
       run: |
         sudo apt install wabt
+    - name: Lint
+      run: |
+        pip install flake8
+        flake8 . --count --select=E7,E9,F63,F7,F82 --show-source --statistics
     - name: Test
       run: |
         pip install pytest

--- a/extra/testutils.py
+++ b/extra/testutils.py
@@ -43,7 +43,7 @@ class Blacklist():
         self._regex = re.compile('|'.join(self._patterns))
 
     def __contains__(self, item):
-        return self._regex.match(item) != None
+        return self._regex.match(item) is not None
 
 def filename(p):
     _, fn = os.path.split(p)

--- a/platforms/python/examples/pygame-raytrace.py
+++ b/platforms/python/examples/pygame-raytrace.py
@@ -52,7 +52,7 @@ while True:
 
     # Render next frame
     wasm_run(t)
-    t += 50;
+    t += 50
 
     # Image output
     img_scaled = pygame.transform.scale(img, scr_size)

--- a/test/run-spec-test.py
+++ b/test/run-spec-test.py
@@ -98,7 +98,7 @@ def escape_str(s):
     if s == "":
         return r'\x00'
 
-    if all((ord(c) < 128 and c.isprintable() and not c in " \n\r\t\\") for c in s):
+    if all((ord(c) < 128 and c.isprintable() and c not in " \n\r\t\\") for c in s):
         return s
 
     return '\\x' + '\\x'.join('{0:02x}'.format(x) for x in s.encode('utf-8'))
@@ -127,7 +127,8 @@ def formatValueFloat(num, t):
         return str(num)
 
     result = "{0:.{1}f}".format(binaryToFloat(num, t), s).rstrip('0')
-    if result.endswith('.'): result = result + '0'
+    if result.endswith('.'):
+        result = result + '0'
     if len(result) > s*2:
         result = "{0:.{1}e}".format(binaryToFloat(num, t), s)
     return result
@@ -262,7 +263,7 @@ class Wasm3():
         while time.time() < tout:
             try:
                 data = self.q.get(timeout=0.1)
-                if data == None:
+                if data is None:
                     error = "Crashed"
                     break
                 buff = buff + data.decode("utf-8")
@@ -282,7 +283,7 @@ class Wasm3():
         self.p.stdin.flush()
 
     def _is_running(self):
-        return self.p and (self.p.poll() == None)
+        return self.p and (self.p.poll() is None)
 
     def _flush_input(self):
         while not self.q.empty():
@@ -405,7 +406,7 @@ def runInvoke(test):
             value = str(test.expected[0]['value'])
             expect = "result " + value
 
-            if actual_val != None:
+            if actual_val is not None:
                 if (t == "f32" or t == "f64") and (value == "nan:canonical" or value == "nan:arithmetic"):
                     val = binaryToFloat(actual_val, t)
                     #warning(f"{actual_val} => {val}")
@@ -448,7 +449,8 @@ def runInvoke(test):
     else:
         stats.failed += 1
         log.write(f"FAIL: {actual}, should be: {expect}\n")
-        if args.silent: return
+        if args.silent:
+            return
 
         showTestResult()
         #sys.exit(1)


### PR DESCRIPTION
Fixes some PEP8 issues with Python code

% `flake8 . --max-line-length=156 --select=E7 --statistics`
```
./platforms/python/examples/pygame-raytrace.py:55:12: E703 statement ends with a semicolon
./test/run-spec-test.py:101:50: E713 test for membership should be 'not in'
./test/run-spec-test.py:130:28: E701 multiple statements on one line (colon)
./test/run-spec-test.py:265:25: E711 comparison to None should be 'if cond is None:'
./test/run-spec-test.py:285:42: E711 comparison to None should be 'if cond is None:'
./test/run-spec-test.py:408:27: E711 comparison to None should be 'if cond is not None:'
./test/run-spec-test.py:451:23: E701 multiple statements on one line (colon)
./extra/testutils.py:46:40: E711 comparison to None should be 'if cond is not None:'
2     E701 multiple statements on one line (colon)
1     E703 statement ends with a semicolon
4     E711 comparison to None should be 'if cond is not None:'
1     E713 test for membership should be 'not in'
```