### PR TITLE
Support compilation with -Wmissing-field-initializers

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -1035,7 +1035,8 @@ M3Result  m3Error  (M3Result i_result, IM3Runtime i_runtime, IM3Module i_module,
 {
     if (i_runtime)
     {
-        i_runtime->error = (M3ErrorInfo){ i_result, i_runtime, i_module, i_function, i_file, i_lineNum };
+        i_runtime->error = (M3ErrorInfo){ .result = i_result, .runtime = i_runtime, .module = i_module,
+                                          .function = i_function, .file = i_file, .line = i_lineNum };
         i_runtime->error.message = i_runtime->error_message;
 
         va_list args;

--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -291,7 +291,7 @@ M3Result  Parse_InitExpr  (M3Module * io_module, bytes_t * io_bytes, cbytes_t i_
 #else
     M3Compilation compilation;
 #endif
-    compilation = (M3Compilation){ NULL, io_module, * io_bytes, i_end };
+    compilation = (M3Compilation){ .runtime = NULL, .module = io_module, .wasm = * io_bytes, .wasmEnd = i_end };
 
     result = CompileBlockStatements (& compilation);
 


### PR DESCRIPTION
While trying to integrate wasm3 in my projects that has some warnings enabled, I hit 2 errors caused by `-Wmissing-field-initializers`:

```
/Users/jf/wasm3/source/m3_parse.c:294:71: warning: missing field 'lastOpcodeStart' initializer [-Wmissing-field-initializers]
    compilation = (M3Compilation){ NULL, io_module, * io_bytes, i_end };
```

Using designated initialisers to initialize the structs makes the warning disappear, and also makes the code a little bit more explicit.