### PR TITLE
Support building on macOS with M1 chip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,11 @@ else()
   set(CMAKE_C_FLAGS_RELEASE "-O3 -Wfatal-errors -fomit-frame-pointer -fno-stack-check -fno-stack-protector") #-fno-inline
 
   if(BUILD_NATIVE)
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=native")
+    if(APPLE AND CMAKE_C_COMPILER_ID MATCHES "Clang" AND CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "arm64")
+      set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -mcpu=native")
+    else()
+      set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=native")
+    endif()
   endif()
 
   set(CMAKE_EXE_LINKER_FLAGS_DEBUG "-O0")


### PR DESCRIPTION
Clang on M1 does not support `-march=native`, so a clean pull and attempt to build of wasm3 fails on these computers. This PR fixes that situation by detecting when user is building on _Apple_ computer using _clang_ compiler and host processor is _arm64_ - using `-mcpu=native` flag instead. 

Building on M1 when using shell as native host:

```sh
$ mkdir -p build && cd build && cmake .. && make
...
Release flags: -O3 -Wfatal-errors -fomit-frame-pointer -fno-stack-check -fno-stack-protector -mcpu=native
...
$ file wasm3
wasm3: Mach-O 64-bit executable arm64
```

Building on M1 when using shell as x86_64 host:

```sh
$ arch -x86_64 bash
$ mkdir -p build && cd build && cmake .. && make
...
Release flags: -O3 -Wfatal-errors -fomit-frame-pointer -fno-stack-check -fno-stack-protector -march=native
...
$ file wasm3
wasm3: Mach-O 64-bit executable x86_64
```
