### PR TITLE
platforms/cpp: use m3_Call and stack access API

### DIFF
--- a/platforms/cpp/wasm3_cpp/include/wasm3_cpp.h
+++ b/platforms/cpp/wasm3_cpp/include/wasm3_cpp.h
@@ -321,25 +321,14 @@ namespace wasm3 {
         /**
          * Call the function with the provided arguments (int/float types).
          *
-         * WASM3 only accepts string arguments when calling WASM functions, and automatically converts them
-         * into the correct type based on the called function signature.
-         *
-         * This function provides a way to pass integer/float types, by first converting them to strings,
-         * and then letting WASM3 do the reverse conversion. This is to be fixed once WASM3 gains an equivalent
-         * of m3_CallArgv which can accept arbitrary types, not just strings.
-         *
          * Note that the type of the return value must be explicitly specified as a template argument.
          *
          * @return the return value of the function.
          */
         template<typename Ret, typename ... Args>
         Ret call(Args... args) {
-            std::string argv_str[] = {std::to_string(args)...};
-            const char* argv[sizeof...(Args)];
-            for (size_t i = 0; i < sizeof...(Args); ++i) {
-                argv[i] = argv_str[i].c_str();
-            }
-            M3Result res = m3_CallArgv(m_func, sizeof...(args), argv);
+            const void *arg_ptrs[] = { reinterpret_cast<const void*>(&args)... };
+            M3Result res = m3_Call(m_func, sizeof...(args), arg_ptrs);
             detail::check_error(res);
             Ret ret;
             const void* ret_ptrs[] = { &ret };


### PR DESCRIPTION
This PR contains two improvements for the C++ wrapper:

1. Use `m3_Call` in `function::call`, getting rid of string conversions.
    When `function::call` was first written, `m3_Call` did not exist yet, and the only way to call functions was through `m3_CallArgv` which takes arguments as strings. Now that `m3_Call` is available, string conversion can be removed.
    Closes https://github.com/wasm3/wasm3/issues/219.
2. Use m3ApiGetArg, m3ApiReturn, m3_GetResults for stack access, resolving some FIXMEs.
    The code still relies on an internal m3_api_defs.h header, but at least it is less likely to get broken, and doesn't depend on `M3Runtime` internals.