### PR TITLE
platforms/esp32: trivial fixes

### DIFF
--- a/platforms/embedded/esp32-idf-wasi/main/main.cpp
+++ b/platforms/embedded/esp32-idf-wasi/main/main.cpp
@@ -55,7 +55,7 @@ static void run_wasm(void)
 
 extern "C" void app_main(void)
 {
-    printf("\nWasm3 v" M3_VERSION " on ESP32, build " __DATE__ " " __TIME__ "\n");
+    printf("\nWasm3 v" M3_VERSION " on " CONFIG_IDF_TARGET ", build " __DATE__ " " __TIME__ "\n");
 
     clock_t start = clock();
     run_wasm();

--- a/platforms/embedded/esp32-idf/main/main.cpp
+++ b/platforms/embedded/esp32-idf/main/main.cpp
@@ -56,7 +56,7 @@ static void run_wasm(void)
 
 extern "C" void app_main(void)
 {
-    printf("\nWasm3 v" M3_VERSION " on ESP32, build " __DATE__ " " __TIME__ "\n");
+    printf("\nWasm3 v" M3_VERSION " on " CONFIG_IDF_TARGET ", build " __DATE__ " " __TIME__ "\n");
 
     clock_t start = clock();
     run_wasm();

--- a/platforms/embedded/esp32-idf/main/main.cpp
+++ b/platforms/embedded/esp32-idf/main/main.cpp
@@ -12,7 +12,6 @@
 #include <unistd.h>
 
 #include "wasm3.h"
-#include "m3_env.h"
 
 #include "extra/fib32.wasm.h"
 
@@ -48,8 +47,11 @@ static void run_wasm(void)
     result = m3_CallV(f, 24);
     if (result) FATAL("m3_Call: %s", result);
 
-    long value = *(uint64_t*)(runtime->stack);
-    printf("Result: %ld\n", value);
+    unsigned value = 0;
+    result = m3_GetResultsV (f, &value);
+    if (result) FATAL("m3_GetResults: %s", result);
+
+    printf("Result: %u\n", value);
 }
 
 extern "C" void app_main(void)

--- a/platforms/embedded/esp32-pio/src/main.cpp
+++ b/platforms/embedded/esp32-pio/src/main.cpp
@@ -56,7 +56,7 @@ static void run_wasm(void)
 
 extern "C" void app_main(void)
 {
-    printf("\nWasm3 v" M3_VERSION " on ESP32, build " __DATE__ " " __TIME__ "\n");
+    printf("\nWasm3 v" M3_VERSION " on " CONFIG_IDF_TARGET ", build " __DATE__ " " __TIME__ "\n");
 
     clock_t start = clock();
     run_wasm();

--- a/platforms/embedded/esp32-pio/src/main.cpp
+++ b/platforms/embedded/esp32-pio/src/main.cpp
@@ -12,7 +12,6 @@
 #include <unistd.h>
 
 #include "wasm3.h"
-#include "m3_env.h"
 
 #include "extra/fib32.wasm.h"
 
@@ -48,8 +47,11 @@ static void run_wasm(void)
     result = m3_CallV(f, 24);
     if (result) FATAL("m3_Call: %s", result);
 
-    long value = *(uint64_t*)(runtime->stack);
-    printf("Result: %ld\n", value);
+    unsigned value = 0;
+    result = m3_GetResultsV (f, &value);
+    if (result) FATAL("m3_GetResults: %s", result);
+
+    printf("Result: %u\n", value);
 }
 
 extern "C" void app_main(void)


### PR DESCRIPTION
1. Use m3_GetResultsV instead of accessing the stack directly.
2. Print the actual chip target name instead of the hard-coded ESP32.