### PR TITLE
Use M3_ prefix for likely/unlikely. Add likely in MemCopy/MemFill functions

### DIFF
--- a/platforms/app/main.c
+++ b/platforms/app/main.c
@@ -56,7 +56,7 @@ m3ApiRawFunction(metering_usegas)
 
     current_gas -= gas;
 
-    if (UNLIKELY(current_gas < 0)) {
+    if (M3_UNLIKELY(current_gas < 0)) {
         m3ApiTrap("[trap] Out of gas");
     }
     m3ApiSuccess();

--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -73,7 +73,7 @@ void *  m3_Realloc  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
 {
     //printf("== realloc %p => %d\n", io_ptr, i_newSize);
 
-    if (UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
+    if (M3_UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
 
     void * newPtr;
 
@@ -122,11 +122,11 @@ void  m3_FreeImpl  (void * io_ptr)
 
 void *  m3_Realloc  (void * i_ptr, size_t i_newSize, size_t i_oldSize)
 {
-    if (UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
+    if (M3_UNLIKELY(i_newSize == i_oldSize)) return i_ptr;
 
     void * newPtr = realloc (i_ptr, i_newSize);
 
-    if (LIKELY(newPtr))
+    if (M3_LIKELY(newPtr))
     {
         if (i_newSize > i_oldSize) {
             memset ((u8 *) newPtr + i_oldSize, 0x0, i_newSize - i_oldSize);
@@ -321,7 +321,7 @@ M3Result  Read_opcode  (m3opcode_t * o_value, bytes_t  * io_bytes, cbytes_t i_en
         m3opcode_t opcode = * ptr++;
 
 #ifndef d_m3EnableExtendedOpcodes
-        if (UNLIKELY(opcode == 0xFC))
+        if (M3_UNLIKELY(opcode == 0xFC))
         {
             if (ptr < i_end)
             {
@@ -550,7 +550,7 @@ u32  FindModuleOffset  (IM3Runtime i_runtime, pc_t i_pc)
 void  PushBacktraceFrame  (IM3Runtime io_runtime, pc_t i_pc)
 {
     // don't try to push any more frames if we've already had an alloc failure
-    if (UNLIKELY (io_runtime->backtrace.lastFrame == M3_BACKTRACE_TRUNCATED))
+    if (M3_UNLIKELY (io_runtime->backtrace.lastFrame == M3_BACKTRACE_TRUNCATED))
         return;
 
     M3BacktraceFrame * newFrame = m3_AllocStruct(M3BacktraceFrame);
@@ -575,7 +575,7 @@ void  FillBacktraceFunctionInfo  (IM3Runtime io_runtime, IM3Function i_function)
 {
     // If we've had an alloc failure then the last frame doesn't refer to the
     // frame we want to fill in the function info for.
-    if (UNLIKELY (io_runtime->backtrace.lastFrame == M3_BACKTRACE_TRUNCATED))
+    if (M3_UNLIKELY (io_runtime->backtrace.lastFrame == M3_BACKTRACE_TRUNCATED))
         return;
 
     if (!io_runtime->backtrace.lastFrame)

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -573,7 +573,7 @@ M3Result  m3_LoadModule  (IM3Runtime io_runtime, IM3Module io_module)
 {
     M3Result result = m3Err_none;
 
-    if (UNLIKELY(io_module->runtime)) {
+    if (M3_UNLIKELY(io_module->runtime)) {
         return m3Err_moduleAlreadyLinked;
     }
 

--- a/source/m3_exception.h
+++ b/source/m3_exception.h
@@ -26,7 +26,7 @@ void ExceptionBreakpoint (cstr_t i_exception, cstr_t i_message);
 #define _try
 #define _(TRY)                            { result = TRY; if (result) { EXCEPTION_PRINT (result); goto _catch; } }
 #define _throw(ERROR)                     { result = ERROR; EXCEPTION_PRINT (result); goto _catch; }
-#define _throwif(ERROR, COND)             if (UNLIKELY(COND)) \
+#define _throwif(ERROR, COND)             if (M3_UNLIKELY(COND)) \
                                           { result = ERROR; EXCEPTION_PRINT (result); goto _catch; }
 
 #define _throwifnull(PTR)                   _throwif (m3Err_mallocFailed, !(PTR))

--- a/source/m3_math_utils.h
+++ b/source/m3_math_utils.h
@@ -92,7 +92,7 @@ float rintf( float arg ) {
   union { float f; uint32_t i; } u;
   u.f = arg;
   uint32_t ux = u.i & 0x7FFFFFFF;
-  if (UNLIKELY(ux == 0 || ux > 0x5A000000)) {
+  if (M3_UNLIKELY(ux == 0 || ux > 0x5A000000)) {
     return arg;
   }
   return (float)lrint(arg);
@@ -103,7 +103,7 @@ double rint( double arg ) {
   union { double f; uint32_t i[2]; } u;
   u.f = arg;
   uint32_t ux = u.i[1] & 0x7FFFFFFF;
-  if (UNLIKELY((ux == 0 && u.i[0] == 0) || ux > 0x433FFFFF)) {
+  if (M3_UNLIKELY((ux == 0 && u.i[0] == 0) || ux > 0x433FFFFF)) {
     return arg;
   }
   return (double)lrint(arg);
@@ -154,26 +154,26 @@ u64 rotr64(u64 n, unsigned c) {
  */
 
 #define OP_DIV_U(RES, A, B)                                      \
-    if (UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero);    \
+    if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero);    \
     RES = A / B;
 
 #define OP_REM_U(RES, A, B)                                      \
-    if (UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero);    \
+    if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero);    \
     RES = A % B;
 
 // 2's complement detection
 #if (INT_MIN != -INT_MAX)
 
     #define OP_DIV_S(RES, A, B, TYPE_MIN)                         \
-        if (UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero); \
-        if (UNLIKELY(B == -1 and A == TYPE_MIN)) {                \
+        if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero); \
+        if (M3_UNLIKELY(B == -1 and A == TYPE_MIN)) {                \
             newTrap (m3Err_trapIntegerOverflow);                  \
         }                                                         \
         RES = A / B;
 
     #define OP_REM_S(RES, A, B, TYPE_MIN)                         \
-        if (UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero); \
-        if (UNLIKELY(B == -1 and A == TYPE_MIN)) RES = 0;         \
+        if (M3_UNLIKELY(B == 0)) newTrap (m3Err_trapDivisionByZero); \
+        if (M3_UNLIKELY(B == -1 and A == TYPE_MIN)) RES = 0;         \
         else RES = A % B;
 
 #else
@@ -188,10 +188,10 @@ u64 rotr64(u64 n, unsigned c) {
  */
 
 #define OP_TRUNC(RES, A, TYPE, RMIN, RMAX)                  \
-    if (UNLIKELY(isnan(A))) {                               \
+    if (M3_UNLIKELY(isnan(A))) {                               \
         newTrap (m3Err_trapIntegerConversion);              \
     }                                                       \
-    if (UNLIKELY(A <= RMIN or A >= RMAX)) {                 \
+    if (M3_UNLIKELY(A <= RMIN or A >= RMAX)) {                 \
         newTrap (m3Err_trapIntegerOverflow);                \
     }                                                       \
     RES = (TYPE)A;
@@ -208,11 +208,11 @@ u64 rotr64(u64 n, unsigned c) {
 #define OP_U64_TRUNC_F64(RES, A)    OP_TRUNC(RES, A, u64,                   -1.0 , 18446744073709551616.0 )
 
 #define OP_TRUNC_SAT(RES, A, TYPE, RMIN, RMAX, IMIN, IMAX)  \
-    if (UNLIKELY(isnan(A))) {                               \
+    if (M3_UNLIKELY(isnan(A))) {                               \
         RES = 0;                                            \
-    } else if (UNLIKELY(A <= RMIN)) {                       \
+    } else if (M3_UNLIKELY(A <= RMIN)) {                       \
         RES = IMIN;                                         \
-    } else if (UNLIKELY(A >= RMAX)) {                       \
+    } else if (M3_UNLIKELY(A >= RMAX)) {                       \
         RES = IMAX;                                         \
     } else {                                                \
         RES = (TYPE)A;                                      \
@@ -238,29 +238,29 @@ u64 rotr64(u64 n, unsigned c) {
 
 static inline
 f32 min_f32(f32 a, f32 b) {
-    if (UNLIKELY(isnan(a) or isnan(b))) return NAN;
-    if (UNLIKELY(a == 0 and a == b)) return signbit(a) ? a : b;
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? a : b;
     return a > b ? b : a;
 }
 
 static inline
 f32 max_f32(f32 a, f32 b) {
-    if (UNLIKELY(isnan(a) or isnan(b))) return NAN;
-    if (UNLIKELY(a == 0 and a == b)) return signbit(a) ? b : a;
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? b : a;
     return a > b ? a : b;
 }
 
 static inline
 f64 min_f64(f64 a, f64 b) {
-    if (UNLIKELY(isnan(a) or isnan(b))) return NAN;
-    if (UNLIKELY(a == 0 and a == b)) return signbit(a) ? a : b;
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? a : b;
     return a > b ? b : a;
 }
 
 static inline
 f64 max_f64(f64 a, f64 b) {
-    if (UNLIKELY(isnan(a) or isnan(b))) return NAN;
-    if (UNLIKELY(a == 0 and a == b)) return signbit(a) ? b : a;
+    if (M3_UNLIKELY(isnan(a) or isnan(b))) return NAN;
+    if (M3_UNLIKELY(a == 0 and a == b)) return signbit(a) ? b : a;
     return a > b ? a : b;
 }
 #endif

--- a/source/wasm3_defs.h
+++ b/source/wasm3_defs.h
@@ -269,14 +269,4 @@
 #  define M3_LIKELY(x)   (x)
 # endif
 
-// TODO: remove
-# if defined(M3_COMPILER_GCC) || defined(M3_COMPILER_CLANG) || defined(M3_COMPILER_ICC)
-#  define UNLIKELY(x) __builtin_expect(!!(x), 0)
-#  define LIKELY(x)   __builtin_expect(!!(x), 1)
-# else
-#  define UNLIKELY(x) (x)
-#  define LIKELY(x)   (x)
-# endif
-
-
 #endif // wasm3_defs_h


### PR DESCRIPTION
Also remove old unprefixed macros