### PR TITLE
Optimize OP codes when return single value

### DIFF
--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1114,14 +1114,14 @@ M3Result  ReturnValues  (IM3Compilation o, IM3CompilationScope i_functionBlock, 
     if (numReturns)
     {
         // return slots like args are 64-bit aligned
-        u16 returnSlot = numReturns * c_ioSlotCount;
-        u16 stackTop = GetStackTopIndex (o);
+        u16 returnSlot = 0;
+        u16 stackTop = GetStackTopIndex (o) - numReturns + 1;
 
         for (u16 i = 0; i < numReturns; ++i)
         {
-            u8 returnType = GetFuncTypeResultType (i_functionBlock->type, numReturns - 1 - i);
+            u8 returnType = GetFuncTypeResultType (i_functionBlock->type, i);
 
-            u8 stackType = GetStackTypeFromTop (o, i);  // using FromTop so that only dynamic items are checked
+            u8 stackType = GetStackTypeFromTop (o, numReturns - 1 - i);  // using FromTop so that only dynamic items are checked
 
             if (IsStackPolymorphic (o) and stackType == c_m3Type_none)
                 stackType = returnType;
@@ -1130,8 +1130,10 @@ M3Result  ReturnValues  (IM3Compilation o, IM3CompilationScope i_functionBlock, 
 
             if (not IsStackPolymorphic (o))
             {
-                returnSlot -= c_ioSlotCount;
-_               (CopyStackIndexToSlot (o, returnSlot, stackTop--));
+                if (stackTop >= 0 && o->wasmStack [stackTop] != returnSlot)
+_                   (CopyStackIndexToSlot (o, returnSlot, stackTop));
+                stackTop++;
+                returnSlot += c_ioSlotCount;
             }
         }
 
@@ -1632,7 +1634,7 @@ _       (Pop (o));
     u16 numArgs = GetFuncTypeNumParams (i_type);
     u16 numRets = GetFuncTypeNumResults (i_type);
 
-    u16 argTop = topSlot + (numArgs + numRets) * c_ioSlotCount;
+    u16 argTop = topSlot + (numArgs + m3ApiArgOffset(numRets)) * c_ioSlotCount;
 
     while (numArgs--)
     {
@@ -2856,7 +2858,8 @@ _   (AcquireCompilationCodePage (o, & o->page));
 
     pc_t pc = GetPagePC (o->page);
 
-    u16 numRetSlots = GetFunctionNumReturns (o->function) * c_ioSlotCount;
+    u16 numRets = GetFunctionNumReturns (o->function);
+    u16 numRetSlots = m3ApiArgOffset(numRets) * c_ioSlotCount;
 
     for (u16 i = 0; i < numRetSlots; ++i)
         MarkSlotAllocated (o, i);

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -805,8 +805,7 @@ u8 *  GetStackPointerForArgs  (IM3Function i_function)
     u64 * stack = (u64 *) i_function->module->runtime->stack;
     IM3FuncType ftype = i_function->funcType;
 
-    stack += ftype->numRets;
-
+    stack += m3ApiArgOffset(ftype->numRets);
     return (u8 *) stack;
 }
 

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -625,7 +625,7 @@ d_m3Op  (CallRawFunction)
 
     const int nArgs = ftype->numArgs;
     const int nRets = ftype->numRets;
-    u64 * args = sp + nRets;
+    u64 * args = sp + m3ApiArgOffset(nRets);
     for (int i=0; i<nArgs; i++) {
         const int type = ftype->types[nRets + i];
         switch (type) {

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -327,9 +327,11 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 # define m3ApiOffsetToPtr(offset)   (void*)((uint8_t*)_mem + (uint32_t)(offset))
 # define m3ApiPtrToOffset(ptr)      (uint32_t)((uint8_t*)ptr - (uint8_t*)_mem)
 
-# define m3ApiReturnType(TYPE)      TYPE* raw_return = ((TYPE*) (_sp++));
+# define m3ApiReturnType(TYPE)      TYPE* raw_return = ((TYPE*) (_sp));
 # define m3ApiGetArg(TYPE, NAME)    TYPE NAME = * ((TYPE *) (_sp++));
 # define m3ApiGetArgMem(TYPE, NAME) TYPE NAME = (TYPE)m3ApiOffsetToPtr(* ((uint32_t *) (_sp++)));
+
+# define m3ApiArgOffset(numRets)    (numRets > 1 ? numRets - 1 : 0)
 
 # define m3ApiIsNullPtr(addr)       ((void*)(addr) <= _mem)
 # define m3ApiCheckMem(addr, len)   { if (M3_UNLIKELY(((void*)(addr) < _mem) || ((uint64_t)(uintptr_t)(addr) + (len)) > ((uint64_t)(uintptr_t)(_mem)+m3_GetMemorySize(runtime)))) m3ApiTrap(m3Err_trapOutOfBoundsMemoryAccess); }


### PR DESCRIPTION
Hi, when I profiling fib(40), the op calls show that:

```
    496740420  op_SetSlot_i32
    331160281  op_u32_LessThan_ss
    331160280  op_Call
    331160280  op_i32_Subtract_ss
    165580141  op_CopySlot_32     <--- extra op codes in new version
    165580141  op_If_r
    165580140  op_i32_Add_ss
```

Old wasm3 version, fib(40):

```
    496740420  op_SetSlot_i32
    331160281  op_u32_LessThan_ss
    331160280  op_Call
    331160280  op_i32_Subtract_ss
    165580141  op_If_r
    165580140  op_i32_Add_ss
```

I reviewed code then I found that it is because of the **Multi-values support**(#23) 

The new version pushed all Return Values to the stack,  then followed other Argnument Values, this cause more op_CopySlot_xx generated in **ReturnValues** function.

In the real world, most of functions return single value. If the count of return values less or equals than 1, can the stack keeps the same as the old version?  The slot of the last return value also be the first argument value's.

Case1:

| slot | | |
|:-:|:--:|:--:
|0|return0|argument0|
|1||argument1|


Case2:

| slot | | |
|:-:|:--:|:--:
|0|return0||
|1|return1|argument0|
|2||argument1|

BTW: The pywasm3 tests failed, should apply this commit:
https://github.com/coderzh/pywasm3/commit/7ca8225c4f7c37cf3ec8e8113e5f78ecc7c24cf0