### PR TITLE
Fix division by zero warning on FreeBSD libc

### DIFF
--- a/source/m3_api_libc.c
+++ b/source/m3_api_libc.c
@@ -178,11 +178,15 @@ m3ApiRawFunction(m3_libc_printf)
 
 m3ApiRawFunction(m3_libc_clock_ms)
 {
-    m3ApiReturnType (uint32_t)
 #ifdef CLOCKS_PER_SEC
-    m3ApiReturn(clock() / (CLOCKS_PER_SEC/1000));
+    uint32_t clock_divider = CLOCKS_PER_SEC/1000;
+    if (clock_divider != 0) {
+        m3ApiReturnType (uint32_t) m3ApiReturn(clock() / clock_divider);
+    } else {
+        m3ApiReturnType (uint32_t) m3ApiReturn(clock());
+    }
 #else
-    m3ApiReturn(clock());
+    m3ApiReturnType (uint32_t) m3ApiReturn(clock());
 #endif
 }
 


### PR DESCRIPTION
This happens with FreeBSD libc where CLOCKS_PER_SEC is defined as 128.
On Linux the CLOCKS_PER_SEC macro is not a constant, so we can't use
something like:

`#if defined (CLOCKS_PER_SEC) && (CLOCKS_PER_SEC > 1000)`