### PR TITLE
Add minimal build.zig build script

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,0 +1,42 @@
+const std = @import("std");
+
+pub fn build(b: *std.build.Builder) !void {
+    const target = b.standardTargetOptions(.{});
+    const mode = b.standardReleaseOptions();
+
+    const wasm3 = b.addExecutable("wasm3", null);
+    wasm3.setTarget(target);
+    wasm3.setBuildMode(mode);
+    wasm3.install();
+    wasm3.linkLibC();
+
+    if (target.getCpuArch() == .wasm32 and target.getOsTag() == .wasi) {
+        wasm3.linkSystemLibrary("wasi-emulated-process-clocks");
+    }
+
+    wasm3.addIncludeDir("source");
+    wasm3.addCSourceFiles(&.{
+        "source/m3_api_libc.c",
+        "source/m3_api_meta_wasi.c",
+        "source/m3_api_tracer.c",
+        "source/m3_api_uvwasi.c",
+        "source/m3_api_wasi.c",
+        "source/m3_bind.c",
+        "source/m3_code.c",
+        "source/m3_compile.c",
+        "source/m3_core.c",
+        "source/m3_emit.c",
+        "source/m3_env.c",
+        "source/m3_exec.c",
+        "source/m3_function.c",
+        "source/m3_info.c",
+        "source/m3_module.c",
+        "source/m3_optimize.c",
+        "source/m3_parse.c",
+        "source/extensions/m3_extensions.c",
+        "platforms/app/main.c",
+    }, &.{
+        "-Dd_m3HasWASI",
+        "-fno-sanitize=undefined", // TODO investigate UB sites in the codebase, then delete this line.
+    });
+}

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -149,3 +149,33 @@ llc -march=wasm32 -mattr=help
 chromium-browser --single-process --js-flags="--help" 2>&1 | grep wasm
 ```
 
+## Build with Zig
+
+Grab the latest nightly Zig toolchain from [ziglang.org/download], and then simply run:
+
+[ziglang.org/download]: https://ziglang.org/download/
+
+```sh
+zig build
+```
+
+This will install `wasm3` compiled for your target architecture in `zig-out/bin/wasm3`.
+
+In order to build `wasm3` in a mode different than Debug, e.g., in ReleaseFast, pass in
+an appropriate flag like so:
+
+```sh
+zig build -Drelease-fast
+```
+
+If you want to cross-compile to some specific target, pass in the target with a flag like so:
+
+```sh
+zig build -Dtarget=wasm32-wasi
+```
+
+Or if targeting Apple Silicon (this works from *any* host with Zig):
+
+```sh
+zig build -Dtarget=aarch64-macos
+```


### PR DESCRIPTION
The minimal `build.zig` script effectively acts as a (nicer?) alternative to CMake; however, it is minimal in the sense, it currently only includes the necessary ingredients to build `wasm3` with Zig as the build system. As an added bonus though, you get the full cross-compilation power of Zig for free.

Example invocation to build for the host:

```
zig build
```

To target `wasm32-wasi` (currently depends on https://github.com/ziglang/zig/pull/8992):

```
zig build -Dtarget=wasm32-wasi
```

To target `aarch64-macos` from *anywhere* (currently depends on https://github.com/ziglang/zig/pull/9045 due to missing libc macOS headers shipped with Zig):

```
zig build -Dtarget=aarch64-macos
```