### PR TITLE
Allow passing custom UVWASI init options

### DIFF
--- a/source/m3_api_uvwasi.c
+++ b/source/m3_api_uvwasi.c
@@ -17,8 +17,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "uvwasi.h"
-
 #ifndef d_m3EnableWasiTracing
 #  define d_m3EnableWasiTracing     0
 #endif
@@ -926,8 +924,6 @@ m3_wasi_context_t* m3_GetWasiContext()
 
 M3Result  m3_LinkWASI  (IM3Module module)
 {
-    M3Result result = m3Err_none;
-
     #define ENV_COUNT       9
 
     char* env[ENV_COUNT];
@@ -955,6 +951,13 @@ M3Result  m3_LinkWASI  (IM3Module module)
     init_options.envp = (const char **) env;
     init_options.preopenc = PREOPENS_COUNT;
     init_options.preopens = preopens;
+
+    return m3_LinkWASIWithOptions(module, init_options);
+}
+
+M3Result  m3_LinkWASIWithOptions  (IM3Module module, uvwasi_options_t init_options)
+{
+    M3Result result = m3Err_none;
 
     if (!wasi_context) {
         wasi_context = (m3_wasi_context_t*)malloc(sizeof(m3_wasi_context_t));

--- a/source/m3_api_wasi.h
+++ b/source/m3_api_wasi.h
@@ -10,6 +10,10 @@
 
 #include "m3_core.h"
 
+#if defined(d_m3HasUVWASI)
+#include "uvwasi.h"
+#endif
+
 d_m3BeginExternC
 
 typedef struct m3_wasi_context_t
@@ -19,7 +23,13 @@ typedef struct m3_wasi_context_t
     ccstr_t *               argv;
 } m3_wasi_context_t;
 
-M3Result    m3_LinkWASI     (IM3Module io_module);
+M3Result    m3_LinkWASI             (IM3Module io_module);
+
+#if defined(d_m3HasUVWASI)
+
+M3Result    m3_LinkWASIWithOptions	(IM3Module io_module, uvwasi_options_t uvwasiOptions);
+
+#endif
 
 m3_wasi_context_t* m3_GetWasiContext();
 


### PR DESCRIPTION
Expose a public API for clients who want to set their own UVWASI options.
No change for existing `m3_LinkWASI` callers, keeping the original default init options.