### PR TITLE
Resolve issue raised by gcc undefined behaviour sanitizer

### DIFF
--- a/source/m3_code.c
+++ b/source/m3_code.c
@@ -93,7 +93,7 @@ void  EmitWord64  (IM3CodePage i_page, const u64 i_word)
 {
 #if M3_SIZEOF_PTR == 4
                                                                         d_m3Assert (i_page->info.lineIndex+2 <= i_page->info.numLines);
-    * ((u64 *) & i_page->code [i_page->info.lineIndex]) = i_word;
+    memcpy (& i_page->code [i_page->info.lineIndex], &i_word, sizeof (i_word));                 // Avoid unaligned write
     i_page->info.lineIndex += 2;
 #else
                                                                         d_m3Assert (i_page->info.lineIndex+1 <= i_page->info.numLines);

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -584,7 +584,12 @@ M3Result  PushConst  (IM3Compilation o, u64 i_word, u8 i_type)
         {
             if (IsSlotAllocated (o, slot) and IsSlotAllocated (o, slot + 1))
             {
+# if d_m3Use32BitSlots
+                u64 constant;
+                memcpy (&constant, &o->constants [slot - o->slotFirstConstIndex], sizeof (u64));      // Avoid unaligned read
+# else
                 u64 constant = * (u64 *) & o->constants [slot - o->slotFirstConstIndex];
+# endif
 
                 if (constant == i_word)
                 {

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -647,7 +647,11 @@ _           (PushAllocatedSlotAndEmit (o, i_type));
             if (is64BitType)
             {
                 u64 * constant = (u64 *) & o->constants [constTableIndex];
+# if d_m3Use32BitSlots
+                memcpy (constant, & i_word, sizeof (u64));      // Avoid unaligned write
+# else
                 * constant = i_word;
+# endif
             }
             else
             {


### PR DESCRIPTION
Whilst running tests using the gcc sanitizer we see warnings related to reading and writing 64 bit values from unaligned addresses. This happens you are using '32 bit slots'. In this case, the safe way to read the value is with a memcpy. The submitted changes apply this if the slots are 32 bits otherwise using the existing code.

This may appear inefficient, but it's my understanding that modern compilers will replace memcpy calls with mov instructions in simple cases with small fixed sizes like this.

Example warning:

../../../3rdParty/wasm3/source/m3_compile.c:650:28: runtime error: store to misaligned address 0x626000000184 for type 'u64', which requires 8 byte alignment
0x626000000184: note: pointer points here
  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
              ^ 
../../../3rdParty/wasm3/source/m3_compile.c:587:21: runtime error: load of misaligned address 0x626000000184 for type 'u64', which requires 8 byte alignment
0x626000000184: note: pointer points here
  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00
