### PR TITLE
Moved static local varible from `NewCodePage`-function to `M3Runtime`-structure

### DIFF
--- a/source/m3_code.c
+++ b/source/m3_code.c
@@ -6,15 +6,13 @@
 //
 
 #include "m3_code.h"
-
+#include "m3_env.h"
 
 //---------------------------------------------------------------------------------------------------------------------------------
 
 
-IM3CodePage  NewCodePage  (u32 i_minNumLines)
+IM3CodePage  NewCodePage  (IM3Runtime i_runtime, u32 i_minNumLines)
 {
-    static u32 s_sequence = 0;
-
     IM3CodePage page;
 
     u32 pageSize = sizeof (M3CodePageHeader) + sizeof (code_t) * i_minNumLines;
@@ -24,7 +22,7 @@ IM3CodePage  NewCodePage  (u32 i_minNumLines)
 
     if (page)
     {
-        page->info.sequence = ++s_sequence;
+        page->info.sequence = ++i_runtime->newCodePageSequence;
         page->info.numLines = (pageSize - sizeof (M3CodePageHeader)) / sizeof (code_t);
 
 #if d_m3RecordBacktraces

--- a/source/m3_code.h
+++ b/source/m3_code.h
@@ -22,7 +22,7 @@ M3CodePage;
 typedef M3CodePage *    IM3CodePage;
 
 
-IM3CodePage             NewCodePage             (u32 i_minNumLines);
+IM3CodePage             NewCodePage             (IM3Runtime i_runtime, u32 i_minNumLines);
 
 void                    FreeCodePages           (IM3CodePage * io_list);
 

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -1055,7 +1055,7 @@ IM3CodePage  AcquireCodePageWithCapacity  (IM3Runtime i_runtime, u32 i_minLineCo
         page = Environment_AcquireCodePage (i_runtime->environment, i_minLineCount);
 
         if (not page)
-            page = NewCodePage (i_minLineCount);
+            page = NewCodePage (i_runtime, i_minLineCount);
 
         if (page)
             i_runtime->numCodePages++;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -188,6 +188,8 @@ typedef struct M3Runtime
 #if d_m3RecordBacktraces
     M3BacktraceInfo         backtrace;
 #endif
+
+	u32						newCodePageSequence;
 }
 M3Runtime;
 


### PR DESCRIPTION
**In this pull request I moved `static local s_sequence` varible from `NewCodePage`-function to `M3Runtime`-structure.**

Rationale

Investigated multithreading (case1) and multimodule (case 2) usage of wasm3.

- Case 1:
```cpp
thread_1:
	auto wasm1 = new wasm3_instance(wasm_module);
	wasm1->execute_some_functions();
	...
...
thread_N:
	auto wasmN = new wasm3_instance(wasm_module);
	wasmN->execute_some_functions();
	...
```

- Case 2:
```cpp
main thread:
	auto wasm1 = new wasm3_instance(wasm_module);
	...
	auto wasmN = new wasm3_instance(wasm_module);

	wasm1->execute_some_functions();
	...
	wasmN->execute_some_functions();
```	

In wasm3 sources I found many of global variables.  
Most of them are `const` so don't think they are big problem.  

There are also non-const global variables and static local varibles.  
All of them I marked up with special defines in my wasm3-fork: https://github.com/skrphv/wasm3/tree/threadSafety . After that we will not find any `static` words in a wasm3 source.  

So the variables that can cause in problem are `global vars`, `global static vars`, `local static vars`.  

As for me, to achive more thread safety we can do next:
- make global/local static vars `local thread`
- save global/local static vars somewhere outside wasm3_instance and restore them before call execution of different wasm3_instances
- move all global/local static vars into some structures (best choise as for me)
- remove unused

But after investigating I found out that only several variables are used `regulary` (I do not use wasi, so here I skipped it): 
- string buffers in `SPrintFuncTypeSignature`, `SPrintValue`, `SPrintFunctionArgList` - but this functions are used only in `m3_log...` in DEBUG mode.
- `static local s_sequence` variable in `NewCodePage`-function - that is used every time.


In this pull request I moved `static local s_sequence` varible from `NewCodePage`-function to `M3Runtime`-structure.  
That will improve thread safety for my case of wasm3 usage.
