### PR TITLE
Make error constants const

### DIFF
--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -110,9 +110,9 @@ M3ImportContext, * IM3ImportContext;
 // -------------------------------------------------------------------------------------------------------------------------------
 
 # if defined(M3_IMPLEMENT_ERROR_STRINGS)
-#   define d_m3ErrorConst(LABEL, STRING)        M3Result m3Err_##LABEL = { STRING };
+#   define d_m3ErrorConst(LABEL, STRING)        const M3Result m3Err_##LABEL = { STRING };
 # else
-#   define d_m3ErrorConst(LABEL, STRING)        extern M3Result m3Err_##LABEL;
+#   define d_m3ErrorConst(LABEL, STRING)        extern const M3Result m3Err_##LABEL;
 # endif
 
 // -------------------------------------------------------------------------------------------------------------------------------

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -110,7 +110,7 @@ M3ImportContext, * IM3ImportContext;
 // -------------------------------------------------------------------------------------------------------------------------------
 
 # if defined(M3_IMPLEMENT_ERROR_STRINGS)
-#   define d_m3ErrorConst(LABEL, STRING)        const M3Result m3Err_##LABEL = { STRING };
+#   define d_m3ErrorConst(LABEL, STRING)        extern const M3Result m3Err_##LABEL = { STRING };
 # else
 #   define d_m3ErrorConst(LABEL, STRING)        extern const M3Result m3Err_##LABEL;
 # endif


### PR DESCRIPTION
Rust bindgen which automatically generates bindings can now identify this as const static data and produce a signature with the correct mutability.

eg.

```rust
extern "C" {
    pub static m3Err_mallocFailed: M3Result;
}
```

vs

```rust
extern "C" {
    pub static mut m3Err_mallocFailed: M3Result;
}
```