### PR TITLE
Fix memory safety issues found by OSS-Fuzz

### DIFF
--- a/source/m3_code.c
+++ b/source/m3_code.c
@@ -5,6 +5,7 @@
 //  Copyright © 2019 Steven Massey. All rights reserved.
 //
 
+#include <limits.h>
 #include "m3_code.h"
 #include "m3_env.h"
 
@@ -15,9 +16,23 @@ IM3CodePage  NewCodePage  (IM3Runtime i_runtime, u32 i_minNumLines)
 {
     IM3CodePage page;
 
+    // check multiplication overflow
+    if (i_minNumLines > UINT_MAX / sizeof (code_t)) {
+        return NULL;
+    }
     u32 pageSize = sizeof (M3CodePageHeader) + sizeof (code_t) * i_minNumLines;
 
+    // check addition overflow
+    if (pageSize < sizeof (M3CodePageHeader)) {
+        return NULL;
+    }
+
     pageSize = (pageSize + (d_m3CodePageAlignSize-1)) & ~(d_m3CodePageAlignSize-1); // align
+    // check alignment overflow
+    if (pageSize == 0) {
+        return NULL;
+    }
+
     page = (IM3CodePage)m3_Malloc ("M3CodePage", pageSize);
 
     if (page)

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -2698,7 +2698,13 @@ _try {
 _           (PopType (o, type));
         }
     }
-    else o->stackIndex -= numParams;
+    else {
+        if (IsStackPolymorphic (o) && o->block.blockStackIndex + numParams > o->stackIndex) {
+            o->stackIndex = o->block.blockStackIndex;
+        } else {
+            o->stackIndex -= numParams;
+        }
+    }
 
     u16 paramIndex = o->stackIndex;
     block->exitStackIndex = paramIndex; // consume the params at block exit

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -2727,7 +2727,7 @@ _           (PopType (o, type));
         u16 slot = GetSlotForStackIndex (o, paramIndex + i);
         Push (o, type, slot);
 
-        if (slot >= o->slotFirstDynamicIndex)
+        if (slot >= o->slotFirstDynamicIndex && slot != c_slotUnused)
             MarkSlotsAllocatedByType (o, slot, type);
     }
 

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -322,11 +322,8 @@ u16  GetExtraSlotForStackIndex  (IM3Compilation o, u16 i_stackIndex)
 static inline
 void  TouchSlot  (IM3Compilation o, u16 i_slot)
 {
-    if (o->function)
-    {
-        // op_Entry uses this value to track and detect stack overflow
-        o->maxStackSlots = M3_MAX (o->maxStackSlots, i_slot + 1);
-    }
+    // op_Entry uses this value to track and detect stack overflow
+    o->maxStackSlots = M3_MAX (o->maxStackSlots, i_slot + 1);
 }
 
 static inline

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1897,6 +1897,7 @@ _   (CompileBlock (o, blockType, i_opcode));
 static
 M3Result  CompileElseBlock  (IM3Compilation o, pc_t * o_startPC, IM3FuncType i_blockType)
 {
+    IM3CodePage savedPage = o->page;
 _try {
 
     IM3CodePage elsePage;
@@ -1904,19 +1905,17 @@ _   (AcquireCompilationCodePage (o, & elsePage));
 
     * o_startPC = GetPagePC (elsePage);
 
-    IM3CodePage savedPage = o->page;
     o->page = elsePage;
 
 _   (CompileBlock (o, i_blockType, c_waOp_else));
 
 _   (EmitOp (o, op_Branch));
     EmitPointer (o, GetPagePC (savedPage));
-
-    ReleaseCompilationCodePage (o);
-
-    o->page = savedPage;
-
 } _catch:
+    if(o->page != savedPage) {
+        ReleaseCompilationCodePage (o);
+    }
+    o->page = savedPage;
     return result;
 }
 


### PR DESCRIPTION
This PR attempts to fix all the open security-relevant issues found by OSS-Fuzz:
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33457: There was an integer overflow when computing `pageSize`. Fixed in c71d965fe9790f635e08c64b5528c6a16fad91ac
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33554: wasm3 was crashing when trying to push a `Const64` value on the stack. The compilation is supposed to detect stack overflows before execution, but it failed to keep track of slots in context outside of a function (which seems to be the case when evaluating expressions in `InitElements`). Fixed in b1278b80a0cf7d36537c8d070e7e9c5f53c31246
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33555: While pushing the params back onto the stack in `CompileBlock`, `GetSlotForStackIndex` may return `c_slotUnused`. If that is the case, passing the slot to `MarkSlotsAllocatedByType` leads to a crash. In the OSS-Fuzz input, this happened with a polymorphic stack. The fix in 731239bdf71e949428308a7297820dc90431e5f3 prevents calling `MarkSlotsAllocatedByType` when `GetSlotForStackIndex` returns an unused slot.
- https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=36551: Same as above.

In addition, I fixed a couple of things I noticed while running the fuzzer locally:
- a memory leak in `CompileElseBlock` (27c8641faeaa5f0036a522d43e5887f3e596ed4f)
- an integer underflow in stackIndex in ComputeBlock of an else block, when the stack is polymorphic. (01e55ccadfd6366d9b4ec61006908373023c898d)

Finally, I ran all the tests described in https://github.com/wasm3/wasm3/blob/main/docs/Testing.md. This is my first time contributing to this repo, so there's a chance that I am missing context for some of the fixes. Happy to re-work them if needed!
