### PR TITLE
Don't include endian.h unconditionally

### DIFF
--- a/source/wasm3_defs.h
+++ b/source/wasm3_defs.h
@@ -231,7 +231,9 @@
 #  define m3_bswap32(x)     __builtin_bswap32((x))
 #  define m3_bswap64(x)     __builtin_bswap64((x))
 # else
-#  include <endian.h>
+#  ifdef __linux__
+#   include <endian.h>
+#  endif
 #  if defined(__bswap_16)
 #   define m3_bswap16(x)     __bswap_16((x))
 #   define m3_bswap32(x)     __bswap_32((x))


### PR DESCRIPTION
The branch for gcc < 4.8 includes endian.h unconditionally. Unfortunately endian.h is non-standard and is limited to linux according to the docs.
This breaks compilation for OSX PPC