### PR TITLE
w3_defs.h: Ensure that endian.h or stdint.h is included before using uint

### DIFF
--- a/source/wasm3_defs.h
+++ b/source/wasm3_defs.h
@@ -233,6 +233,8 @@
 # else
 #  ifdef __linux__
 #   include <endian.h>
+#  else
+#   include <stdint.h>
 #  endif
 #  if defined(__bswap_16)
 #   define m3_bswap16(x)     __bswap_16((x))


### PR DESCRIPTION
This is an addendum to my previous patch as it missed to ensure inclusion of
some header that provides uint*. It worked for me only because of local flags
to add this include