### PR TITLE
Check for if slot == c_slotUnused in PushConst

### DIFF
--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -722,7 +722,7 @@ _                   (Push (o, i_type, slot));
         u16 slot = c_slotUnused;
         result = AllocateConstantSlots (o, & slot, i_type);
 
-        if (result) // no more constant table space; use inline constants
+        if (result || slot == c_slotUnused) // no more constant table space; use inline constants
         {
             result = m3Err_none;
 


### PR DESCRIPTION
I recently ported wasm3 to my kernel, [chariot](https://github.com/ChariotOS/chariot), and tried to run the coremark test. I'm not sure if this is a problem with any part of my libc, or a problem with wasm3's compiler, but this little change fixed the segfault/assertion failure on line 743. I'm not even sure if this is the correct place in the code to fix the bug.

If this is a problem with my libc/libm and not wasm3 feel free to deny this PR, but I figured I'd provide my fix in case it is helpful.