### PR TITLE
Fix parsing of i32 constant globals on big-endian systems.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,16 @@ jobs:
     - name: Test WASI apps
       run: cd test && python3 run-wasi-test.py
 
+  big-endian-i32-constant:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Get the qemu container
+      run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+    - name: Run tests
+      run: docker run --rm --interactive --mount type=bind,source=$(pwd),target=/host s390x/alpine sh -c "apk add build-base cmake git --update-cache && cd /host && mkdir build && cd build && cmake .. && cd .. && cmake --build build && echo wasm3 built && echo AGFzbQEAAAAGBgF/AEElCwcLAQdteWNvbnN0AwAACARuYW1lAgEA | base64 -d > myconst.wasm && echo ':get-global myconst' | ./build/wasm3 --repl myconst.wasm && echo ':get-global myconst' | ./build/wasm3 --repl myconst.wasm 2>&1 | grep 37"
+
   macos:
     runs-on: macos-latest
     name: macos-${{ matrix.config.target }}

--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1343,7 +1343,7 @@ M3Result  Compile_GetGlobal  (IM3Compilation o, M3Global * i_global)
 
     IM3Operation op = Is64BitType (i_global->type) ? op_GetGlobal_s64 : op_GetGlobal_s32;
 _   (EmitOp (o, op));
-    EmitPointer (o, & i_global->intValue);
+    EmitPointer (o, & i_global->i64Value);
 _   (PushAllocatedSlotAndEmit (o, i_global->type));
 
     _catch: return result;
@@ -1366,7 +1366,7 @@ M3Result  Compile_SetGlobal  (IM3Compilation o, M3Global * i_global)
         else op = Is64BitType (type) ? op_SetGlobal_s64 : op_SetGlobal_s32;
 
 _      (EmitOp (o, op));
-        EmitPointer (o, & i_global->intValue);
+        EmitPointer (o, & i_global->i64Value);
 
         if (IsStackTopInSlot (o))
             EmitSlotOffset (o, GetStackTopSlotNumber (o));

--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -424,7 +424,8 @@ M3Result  InitGlobals  (IM3Module io_module)
                 if (g->initExpr)
                 {
                     bytes_t start = g->initExpr;
-                    result = EvaluateExpression (io_module, & g->intValue, g->type, & start, g->initExpr + g->initExprSize);
+
+                    result = EvaluateExpression (io_module, & g->i64Value, g->type, & start, g->initExpr + g->initExprSize);
 
                     if (not result)
                     {
@@ -648,8 +649,8 @@ M3Result  m3_GetGlobal  (IM3Global                 i_global,
     if (not i_global) return m3Err_globalLookupFailed;
 
     switch (i_global->type) {
-    case c_m3Type_i32: o_value->value.i32 = i_global->intValue; break;
-    case c_m3Type_i64: o_value->value.i64 = i_global->intValue; break;
+    case c_m3Type_i32: o_value->value.i32 = i_global->i32Value; break;
+    case c_m3Type_i64: o_value->value.i64 = i_global->i64Value; break;
 # if d_m3HasFloat
     case c_m3Type_f32: o_value->value.f32 = i_global->f32Value; break;
     case c_m3Type_f64: o_value->value.f64 = i_global->f64Value; break;
@@ -670,8 +671,8 @@ M3Result  m3_SetGlobal  (IM3Global                 i_global,
     if (i_global->type != i_value->type) return m3Err_globalTypeMismatch;
 
     switch (i_value->type) {
-    case c_m3Type_i32: i_global->intValue = i_value->value.i32; break;
-    case c_m3Type_i64: i_global->intValue = i_value->value.i64; break;
+    case c_m3Type_i32: i_global->i32Value = i_value->value.i32; break;
+    case c_m3Type_i64: i_global->i64Value = i_value->value.i64; break;
 # if d_m3HasFloat
     case c_m3Type_f32: i_global->f32Value = i_value->value.f32; break;
     case c_m3Type_f64: i_global->f64Value = i_value->value.f64; break;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -58,7 +58,8 @@ typedef struct M3Global
 
     union
     {
-        i64 intValue;
+        i32 i32Value;
+        i64 i64Value;
 #if d_m3HasFloat
         f64 f64Value;
         f32 f32Value;


### PR DESCRIPTION
Issue #321: This replaces `intValue` in the global value union with
separate `i32Value` and `i64Value`. A CI test is added against s390x.