### PR TITLE
m3_env.c: prefer export name in searching function

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -690,6 +690,16 @@ M3ValueType  m3_GetGlobalType  (IM3Global          i_global)
 
 void *  v_FindFunction  (IM3Module i_module, const char * const i_name)
 {
+
+    // Prefer exported functions
+    for (u32 i = 0; i < i_module->numFunctions; ++i)
+    {
+        IM3Function f = & i_module->functions [i];
+        if (f->export_name and strcmp (f->export_name, i_name) == 0)
+            return f;
+    }
+
+    // Search internal functions
     for (u32 i = 0; i < i_module->numFunctions; ++i)
     {
         IM3Function f = & i_module->functions [i];

--- a/source/m3_function.h
+++ b/source/m3_function.h
@@ -48,6 +48,7 @@ typedef struct M3Function
     bytes_t                 wasmEnd;
 
     cstr_t                  names[d_m3MaxDuplicateFunctionImpl];
+    cstr_t                  export_name;                            // should be a part of "names"
     u16                     numNames;                               // maximum of d_m3MaxDuplicateFunctionImpl
 
     IM3FuncType             funcType;

--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -244,6 +244,7 @@ _       (ReadLEB_u32 (& index, & i_bytes, i_end));                              
             if (func->numNames < d_m3MaxDuplicateFunctionImpl)
             {
                 func->names[func->numNames++] = utf8;
+                func->export_name = utf8;
                 utf8 = NULL; // ownership transferred to M3Function
             }
         }


### PR DESCRIPTION
Since https://reviews.llvm.org/D81689, wasm-ld has started wrapping
all exported functions including "_start" with surrounding ctor/dtor
calls. The wrapper function "_start.command_export" is exposed as
"_start".
wasm3 searched the entry function by looking up names indiscriminately.
However, it sometimes found the internal "_start" function, so ctor/dtor
were not called. To pick up the wrapper "_start", this patch changes to
search export names at first.

This issue has been found in SwiftWasm project https://github.com/swiftwasm/swift/issues/4437