### PR TITLE
Fix Cygwin compatibility

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -154,6 +154,19 @@ jobs:
         cd test
         python run-wasi-test.py
 
+  cygwin-build:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@main
+      - name: Set up Cygwin
+        uses: egor-tensin/setup-cygwin@master
+        with:
+            platform: x64
+            packages: make gcc-g++ cmake
+      - run: cd $GITHUB_WORKSPACE && cmake -DBUILD_WASI=simple . && make
+        shell: C:\tools\cygwin\bin\bash.exe --login --norc -eo pipefail -o igncr '{0}'
+
   wasi:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/source/m3_api_wasi.c
+++ b/source/m3_api_wasi.c
@@ -33,7 +33,7 @@
 #if defined(APE)
 // Actually Portable Executable
 // All functions are already included in cosmopolitan.h
-#elif defined(__wasi__) || defined(__APPLE__) || defined(__ANDROID_API__) || defined(__OpenBSD__) || defined(__linux__) || defined(__EMSCRIPTEN__)
+#elif defined(__wasi__) || defined(__APPLE__) || defined(__ANDROID_API__) || defined(__OpenBSD__) || defined(__linux__) || defined(__EMSCRIPTEN__) || defined(__CYGWIN__)
 #  include <unistd.h>
 #  include <sys/uio.h>
 #  if defined(__APPLE__)

--- a/source/m3_config_platforms.h
+++ b/source/m3_config_platforms.h
@@ -67,7 +67,7 @@
 #  define M3_WEAK //__declspec(selectany)
 #  define M3_NO_UBSAN
 #  define M3_NOINLINE
-# elif defined(__MINGW32__)
+# elif defined(__MINGW32__) || defined(__CYGWIN__)
 #  define M3_WEAK //__attribute__((selectany))
 #  define M3_NO_UBSAN
 #  define M3_NOINLINE   __attribute__((noinline))


### PR DESCRIPTION
This PR makes a few trivial changes to confer Cygwin compatibility. A CI job is added to prevent regressions.