### PR TITLE
Allow C++ enum classes to be marshalled as integers when possible.

### DIFF
--- a/platforms/cpp/wasm3_cpp/include/wasm3_cpp.h
+++ b/platforms/cpp/wasm3_cpp/include/wasm3_cpp.h
@@ -44,7 +44,18 @@ namespace wasm3 {
         struct m3_sig {
             static const char value = c;
         };
-        template<typename T> struct m3_type_to_sig;
+        template<typename T, typename = void> struct m3_type_to_sig;
+
+        template<typename T, typename U>
+        using is_enum_of_t = typename std::enable_if<std::is_enum<T>::value
+            && std::is_same<std::underlying_type_t<T>, U>::value>::type;
+
+        template<typename T>
+        struct m3_type_to_sig<T, is_enum_of_t<T, int32_t>> : m3_sig<'i'> {};
+
+        template<class T>
+        struct m3_type_to_sig<T, is_enum_of_t<T, int64_t>> : m3_sig<'I'> {};
+
         template<> struct m3_type_to_sig<int32_t> : m3_sig<'i'> {};
         template<> struct m3_type_to_sig<int64_t> : m3_sig<'I'> {};
         template<> struct m3_type_to_sig<float>   : m3_sig<'f'> {};


### PR DESCRIPTION
With C++ enum classes, the size of an enum object can vary depending
on the compiler generation mechanism (choosing the most optimal storage size
to contain all the variants) or a user-defined storage type. In wasm, we
can only send int32_t and int64_t. That means, the enums using this
integer width for storage must also work properly. At runtime this works
flawlessly, the functions in wasm can return these values safely and
they are even converted back on the C++ side to their enum
representations, thanks to the code in wasm3 which does a cast an
integer cast. But when it comes to generating the code for function
arguments, the defined data structure is not enough to generalize the
code to allow enum classes even if they are of a proper (allowed) width.

This commit changes the defined data structure to create a data
structure literal for wasm so that it allows enum classes as well as
already defined data types.

P.S. Probably we can also allow enum classes of a lesser width to "serialize"
to an integer of a closest bigger width, like `enum class : uint8_t` as
`int32_t` if all the other code is fine with that. Another way of allowing a
more generic approach is to define an interface where we define methods like
`int32_t to_integer()` and `T from_integer(const int32_t)` and if this interface is
defined for a type `T` which is passed here, we would use the interface's internal
`::type` to define what width it should be in wasm. Another, third thing, is just to check for
user-defined conversion.
