### PR TITLE
fix reading all function names and avoid memory leak

### DIFF
--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -506,13 +506,11 @@ _               (Read_utf8 (& name, & i_bytes, i_end));
                 if (index < io_module->numFunctions)
                 {
                     IM3Function func = &(io_module->functions [index]);
-                    if (func->numNames == 0)
+                    if (func->numNames < d_m3MaxDuplicateFunctionImpl)
                     {
-                        func->names[0] = name;        m3log (parse, "    naming function%5d:  %s", index, name);
-                        func->numNames = 1;
+                        func->names[func->numNames++] = name;        m3log (parse, "    naming function%5d:  %s", index, name);
                         name = NULL; // transfer ownership
                     }
-//                          else m3log (parse, "prenamed: %s", io_module->functions [index].name);
                 }
 
                 m3_Free (name);


### PR DESCRIPTION
If a function is exported, the exported name is read first and the internal name reading overwrites it, causing a missing name and a memory leak.

The export here happens first:
https://github.com/wasm3/wasm3/blob/9dcfce271c2fac86823725fc9ec0f75309d820e4/source/m3_parse.c#L240

Then it gets possibly (if exported) overwritten here:
https://github.com/wasm3/wasm3/blob/9dcfce271c2fac86823725fc9ec0f75309d820e4/source/m3_parse.c#L509

This PR fixes this issue.