### PR TITLE
Replace C array with std::array to handle zero length

### DIFF
--- a/platforms/cpp/wasm3_cpp/include/wasm3_cpp.h
+++ b/platforms/cpp/wasm3_cpp/include/wasm3_cpp.h
@@ -5,6 +5,7 @@
 #include <type_traits>
 #include <iostream>
 #include <vector>
+#include <array>
 #include <memory>
 #include <string>
 #include <iterator>
@@ -348,8 +349,8 @@ namespace wasm3 {
          */
         template<typename Ret = void, typename ... Args>
         Ret call(Args... args) {
-            const void *arg_ptrs[] = { reinterpret_cast<const void*>(&args)... };
-            M3Result res = m3_Call(m_func, sizeof...(args), arg_ptrs);
+            std::array<const void*, sizeof...(args)> arg_ptrs{ reinterpret_cast<const void*>(&args)... };
+            M3Result res = m3_Call(m_func, arg_ptrs.size(), arg_ptrs.data());
             detail::check_error(res);
 
             if constexpr (!std::is_void<Ret>::value) {


### PR DESCRIPTION
This change is to address #368. Standard C++ does not allow zero length arrays, this only works with compiler extensions. This change replaces the use a C array with an std:array which can be of length zero, but is still statically sized at compile time (e.g. `.size()` is `constexpr`).