### PR TITLE
bugfix: remove module from the list when calling m3_FreeModule.

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -606,6 +606,10 @@ _   (InitElements (io_module));
 #endif
 
     io_module->next = io_runtime->modules;
+    if (io_runtime->modules)
+    {
+        io_runtime->modules->prev = io_module;
+    }
     io_runtime->modules = io_module;
     return result; // ok
 

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -116,6 +116,7 @@ typedef struct M3Module
 
     //bool                    hasWasmCodeCopy;
 
+    struct M3Module *       prev;
     struct M3Module *       next;
 }
 M3Module;

--- a/source/m3_module.c
+++ b/source/m3_module.c
@@ -28,6 +28,21 @@ void  m3_FreeModule  (IM3Module i_module)
 
         Module_FreeFunctions (i_module);
 
+        if (i_module->runtime && i_module->runtime->modules == i_module)
+        {
+            i_module->runtime->modules = i_module->next;
+        }
+
+        if (i_module->prev)
+        {
+            i_module->prev->next = i_module->next;
+        }
+
+        if (i_module->next)
+        {
+            i_module->next->prev = i_module->prev;
+        }
+
         m3_Free (i_module->functions);
         //m3_Free (i_module->imports);
         m3_Free (i_module->funcTypes);


### PR DESCRIPTION
A module maybe freed after it is loaded to the runtime and before the runtime is released. Hence, it is necessary to remove the module from the runtime's module list to avoid one module be freed twice.

Fix #389