### PR TITLE
Remove alignment attributes defined as vectorcall.  The compiler inte…

### DIFF
--- a/source/m3_config_platforms.h
+++ b/source/m3_config_platforms.h
@@ -127,9 +127,9 @@ typedef int8_t          i8;
 # if defined (M3_COMPILER_MSVC)
 #   define vectorcall   // For MSVC, better not to specify any call convention
 # elif defined(__x86_64__)
-#   define vectorcall   __attribute__((aligned(32)))
+#   define vectorcall
 //# elif defined(__riscv) && (__riscv_xlen == 64)
-//#   define vectorcall   __attribute__((aligned(16)))
+//#   define vectorcall
 # elif defined(__MINGW32__)
 #   define vectorcall
 # elif defined(WIN32)


### PR DESCRIPTION
…rprets this as an alignment requirement on the pointer itself, not what it points to, which is probably not what was intended.