### PR TITLE
Fix operations preventing tail-call-elimination:

### DIFF
--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -1302,12 +1302,14 @@ d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_r)                 \
     if (m3MemCheck(                                     \
         operand + sizeof (SRC_TYPE) <= _mem->length     \
     )) {                                                \
-        u8* src8 = m3MemData(_mem) + operand;           \
-        SRC_TYPE value;                                 \
-        memcpy(&value, src8, sizeof(value));            \
-        M3_BSWAP_##SRC_TYPE(value);                     \
-        REG = (DEST_TYPE)value;                         \
-        d_m3TraceLoad(DEST_TYPE, operand, REG);         \
+        {                                               \
+            u8* src8 = m3MemData(_mem) + operand;       \
+            SRC_TYPE value;                             \
+            memcpy(&value, src8, sizeof(value));        \
+            M3_BSWAP_##SRC_TYPE(value);                 \
+            REG = (DEST_TYPE)value;                     \
+            d_m3TraceLoad(DEST_TYPE, operand, REG);     \
+        }                                               \
         nextOp ();                                      \
     } else d_outOfBounds;                               \
 }                                                       \
@@ -1321,12 +1323,14 @@ d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_s)                 \
     if (m3MemCheck(                                     \
         operand + sizeof (SRC_TYPE) <= _mem->length     \
     )) {                                                \
-        u8* src8 = m3MemData(_mem) + operand;           \
-        SRC_TYPE value;                                 \
-        memcpy(&value, src8, sizeof(value));            \
-        M3_BSWAP_##SRC_TYPE(value);                     \
-        REG = (DEST_TYPE)value;                         \
-        d_m3TraceLoad(DEST_TYPE, operand, REG);         \
+        {                                               \
+            u8* src8 = m3MemData(_mem) + operand;       \
+            SRC_TYPE value;                             \
+            memcpy(&value, src8, sizeof(value));        \
+            M3_BSWAP_##SRC_TYPE(value);                 \
+            REG = (DEST_TYPE)value;                     \
+            d_m3TraceLoad(DEST_TYPE, operand, REG);     \
+        }                                               \
         nextOp ();                                      \
     } else d_outOfBounds;                               \
 }
@@ -1367,11 +1371,13 @@ d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_rs)             \
     if (m3MemCheck(                                     \
         operand + sizeof (DEST_TYPE) <= _mem->length    \
     )) {                                                \
-        d_m3TraceStore(SRC_TYPE, operand, REG);         \
-        u8* mem8 = m3MemData(_mem) + operand;           \
-        DEST_TYPE val = (DEST_TYPE) REG;                \
-        M3_BSWAP_##DEST_TYPE(val);                      \
-        memcpy(mem8, &val, sizeof(val));                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, REG);     \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            DEST_TYPE val = (DEST_TYPE) REG;            \
+            M3_BSWAP_##DEST_TYPE(val);                  \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
         nextOp ();                                      \
     } else d_outOfBounds;                               \
 }                                                       \
@@ -1386,11 +1392,13 @@ d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_sr)             \
     if (m3MemCheck(                                     \
         operand + sizeof (DEST_TYPE) <= _mem->length    \
     )) {                                                \
-        d_m3TraceStore(SRC_TYPE, operand, value);       \
-        u8* mem8 = m3MemData(_mem) + operand;           \
-        DEST_TYPE val = (DEST_TYPE) value;              \
-        M3_BSWAP_##DEST_TYPE(val);                      \
-        memcpy(mem8, &val, sizeof(val));                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, value);   \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            DEST_TYPE val = (DEST_TYPE) value;          \
+            M3_BSWAP_##DEST_TYPE(val);                  \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
         nextOp ();                                      \
     } else d_outOfBounds;                               \
 }                                                       \
@@ -1405,11 +1413,13 @@ d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_ss)             \
     if (m3MemCheck(                                     \
         operand + sizeof (DEST_TYPE) <= _mem->length    \
     )) {                                                \
-        d_m3TraceStore(SRC_TYPE, operand, value);       \
-        u8* mem8 = m3MemData(_mem) + operand;           \
-        DEST_TYPE val = (DEST_TYPE) value;              \
-        M3_BSWAP_##DEST_TYPE(val);                      \
-        memcpy(mem8, &val, sizeof(val));                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, value);   \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            DEST_TYPE val = (DEST_TYPE) value;          \
+            M3_BSWAP_##DEST_TYPE(val);                  \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
         nextOp ();                                      \
     } else d_outOfBounds;                               \
 }
@@ -1426,11 +1436,13 @@ d_m3Op  (TYPE##_Store_##TYPE##_rr)                      \
     if (m3MemCheck(                                     \
         operand + sizeof (TYPE) <= _mem->length         \
     )) {                                                \
-        d_m3TraceStore(TYPE, operand, REG);             \
-        u8* mem8 = m3MemData(_mem) + operand;           \
-        TYPE val = (TYPE) REG;                          \
-        M3_BSWAP_##TYPE(val);                           \
-        memcpy(mem8, &val, sizeof(val));                \
+        {                                               \
+            d_m3TraceStore(TYPE, operand, REG);         \
+            u8* mem8 = m3MemData(_mem) + operand;       \
+            TYPE val = (TYPE) REG;                      \
+            M3_BSWAP_##TYPE(val);                       \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
         nextOp ();                                      \
     } else d_outOfBounds;                               \
 }


### PR DESCRIPTION
If the compiler cannot analyze memcpy, it must expect that pointer arguments may be stored as static data and must live for recursive calls. In such cases, op_Store and op_Load operations will not get tail-call optimized. By enclosing the local variables in a block before the recursive call, the storage duration does not extend far enough, allowing for TCO.

Closes #401 

Assembly code emitted after fix:
Notice the call at `+110` is a tail-call now.
```
Dump of assembler code for function op_i32_Store_i32_ss:
   0x000113ac <+0>:	stmdb	sp!, {r4, r5, r6, r7, r8, r9, lr}
   0x000113b0 <+4>:	mov	r5, r0
   0x000113b2 <+6>:	mov	r7, r2
   0x000113b4 <+8>:	mov.w	r12, #0
   0x000113b8 <+12>:	mov	r6, r1
   0x000113ba <+14>:	vpush	{d8}
   0x000113be <+18>:	ldr	r3, [r0, #4]
   0x000113c0 <+20>:	sub	sp, #20
   0x000113c2 <+22>:	ldr	r4, [r5, #8]
   0x000113c4 <+24>:	ldr.w	r0, [r1, r3, lsl #2]
   0x000113c8 <+28>:	ldr	r3, [r5, #0]
   0x000113ca <+30>:	ldr.w	lr, [r1, r3, lsl #2]
   0x000113ce <+34>:	adds	r3, r4, #4
   0x000113d0 <+36>:	ldr	r1, [r7, #8]
   0x000113d2 <+38>:	adc.w	r2, r12, #0
   0x000113d6 <+42>:	adds	r3, r3, r0
   0x000113d8 <+44>:	adc.w	r2, r2, #0
   0x000113dc <+48>:	cmp	r1, r3
   0x000113de <+50>:	sbcs.w	r3, r12, r2
   0x000113e2 <+54>:	ldrd	r8, r9, [sp, #56]	; 0x38
   0x000113e6 <+58>:	bcc.n	0x1141c <op_i32_Store_i32_ss+112>
   0x000113e8 <+60>:	adds	r4, #12
   0x000113ea <+62>:	vmov.f64	d8, d0
   0x000113ee <+66>:	add	r1, sp, #12
   0x000113f0 <+68>:	movs	r2, #4
   0x000113f2 <+70>:	add	r0, r4
   0x000113f4 <+72>:	str.w	lr, [sp, #12]
   0x000113f8 <+76>:	add	r0, r7
   0x000113fa <+78>:	bl	0x7e4 <memcpy>
   0x000113fe <+82>:	vmov.f64	d0, d8
   0x00011402 <+86>:	mov	r2, r7
   0x00011404 <+88>:	mov	r1, r6
   0x00011406 <+90>:	add.w	r0, r5, #16
   0x0001140a <+94>:	strd	r8, r9, [sp, #56]	; 0x38
   0x0001140e <+98>:	ldr	r3, [r5, #12]
   0x00011410 <+100>:	add	sp, #20
   0x00011412 <+102>:	vpop	{d8}
   0x00011416 <+106>:	ldmia.w	sp!, {r4, r5, r6, r7, r8, r9, lr}
   0x0001141a <+110>:	bx	r3
   0x0001141c <+112>:	add.w	r2, r5, #8
   0x00011420 <+116>:	ldr	r0, [r7, #0]
   0x00011422 <+118>:	mov	r3, r6
   0x00011424 <+120>:	mov	r1, r2
   0x00011426 <+122>:	strd	r8, r9, [sp]
   0x0001142a <+126>:	bl	0x1a6d8 <PushBacktraceFrame>
   0x0001142e <+130>:	ldr	r3, [pc, #12]	; (0x1143c <op_i32_Store_i32_ss+144>)
   0x00011430 <+132>:	ldr	r0, [r3, #0]
   0x00011432 <+134>:	add	sp, #20
   0x00011434 <+136>:	vpop	{d8}
   0x00011438 <+140>:	ldmia.w	sp!, {r4, r5, r6, r7, r8, r9, pc}
   0x0001143c <+144>:	asrs	r4, r3, #8
   0x0001143e <+146>:	movs	r2, r0
```