### PR TITLE
Bump up some default limits to align with mainstream wasm implementations

### DIFF
--- a/source/m3_core.h
+++ b/source/m3_core.h
@@ -162,14 +162,14 @@ M3CodePageHeader;
 #define d_m3Reg0SlotAlias                   60000
 #define d_m3Fp0SlotAlias                    (d_m3Reg0SlotAlias + 2)
 
-#define d_m3MaxSaneTypesCount               100000
-#define d_m3MaxSaneFunctionsCount           100000
-#define d_m3MaxSaneImportsCount             10000
-#define d_m3MaxSaneExportsCount             10000
-#define d_m3MaxSaneGlobalsCount             100000
-#define d_m3MaxSaneElementSegments          100000
+#define d_m3MaxSaneTypesCount               1000000
+#define d_m3MaxSaneFunctionsCount           1000000
+#define d_m3MaxSaneImportsCount             100000
+#define d_m3MaxSaneExportsCount             100000
+#define d_m3MaxSaneGlobalsCount             1000000
+#define d_m3MaxSaneElementSegments          10000000
 #define d_m3MaxSaneDataSegments             100000
-#define d_m3MaxSaneTableSize                100000
+#define d_m3MaxSaneTableSize                10000000
 #define d_m3MaxSaneUtf8Length               10000
 #define d_m3MaxSaneFunctionArgRetCount      1000    // still insane, but whatever
 


### PR DESCRIPTION
This commit bumps up some default limit values to align with some mainstream implementations, and allows wasm3 to execute some larger wasm32 modules that it would previously report errors like "too many functions" and such. There are specialized m3_core.h for more restricted platforms, and this commit doesn't touch those, so it shouldn't increase the overhead on those platforms.

Wasm spec discussion: https://github.com/WebAssembly/spec/issues/607
V8 limits: https://chromium.googlesource.com/v8/v8/+/master/src/wasm/wasm-limits.h
SpiderMonkey limits: https://hg.mozilla.org/mozilla-central/file/tip/js/src/wasm/WasmConstants.h
JavaScriptCore limits: https://github.com/WebKit/WebKit/blob/main/Source/JavaScriptCore/wasm/WasmLimits.h