### PR TITLE
Fix dangling runtime pointer when stack cannot be allocated

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -187,7 +187,11 @@ IM3Runtime  m3_NewRuntime  (IM3Environment i_environment, u32 i_stackSizeInBytes
         {
             runtime->numStackSlots = i_stackSizeInBytes / sizeof (m3slot_t);         m3log (runtime, "new stack: %p", runtime->stack);
         }
-        else m3_Free (runtime);
+        else
+        {
+            m3_Free (runtime);
+            runtime = NULL;
+        }
     }
 
     return runtime;


### PR DESCRIPTION
When calling `m3_NewRuntime`, if `runtime` is non-null and `runtime->stack` is null, then `runtime` is freed and returned without signaling any error. This pointer is dangling. The suggested fix is to set it back to null after free, which signals an error to the caller and prevents pointer misuse.