### PR TITLE
Fix functions with musttail attribute

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -297,8 +297,12 @@ M3Result  EvaluateExpression  (IM3Module i_module, void * o_expressed, u8 i_type
 
         if (not result)
         {
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+            m3ret_t r = RunCode (m3code, stack, NULL, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
             m3ret_t r = RunCode (m3code, stack, NULL, d_m3OpDefaultArgs);
-
+# endif
+            
             if (r == 0)
             {                                                                               m3log (runtime, "expression result: %s", SPrintValue (stack, i_type));
                 if (SizeOfType (i_type) == sizeof (u32))
@@ -568,7 +572,11 @@ _           (CompileFunction (function));
         startFunctionTmp = io_module->startFunction;
         io_module->startFunction = -1;
 
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+        result = (M3Result) RunCode (function->compiled, (m3stack_t) runtime->stack, runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
         result = (M3Result) RunCode (function->compiled, (m3stack_t) runtime->stack, runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
 
         if (result)
         {
@@ -875,7 +883,11 @@ _   (checkStartFunction(i_function->module))
         }
     }
 
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
     result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
     ReportNativeStackUsage ();
 
     runtime->lastCalled = result ? NULL : i_function;
@@ -920,7 +932,12 @@ _   (checkStartFunction(i_function->module))
         }
     }
 
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
     result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
+
     ReportNativeStackUsage ();
 
     runtime->lastCalled = result ? NULL : i_function;
@@ -965,7 +982,12 @@ _   (checkStartFunction(i_function->module))
         }
     }
 
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
     result = (M3Result) RunCode (i_function->compiled, (m3stack_t)(runtime->stack), runtime->memory.mallocated, d_m3OpDefaultArgs);
+# endif
+    
     ReportNativeStackUsage ();
 
     runtime->lastCalled = result ? NULL : i_function;

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -108,8 +108,11 @@ d_m3BeginExternC
 
 #endif
 
-
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+d_m3RetSig  Call  (d_m3OpSig, cstr_t i_operationName)
+# else
 d_m3RetSig  Call  (d_m3OpSig)
+# endif
 {
     m3ret_t possible_trap = m3_Yield ();
     if (M3_UNLIKELY(possible_trap)) return possible_trap;
@@ -537,7 +540,12 @@ d_m3Op  (Call)
 
     m3stack_t sp = _sp + stackOffset;
 
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
     m3ret_t r = Call (callPC, sp, _mem, d_m3OpDefaultArgs);
+# endif
+
     _mem = memory->mallocated;
 
     if (M3_LIKELY(not r))
@@ -575,7 +583,13 @@ d_m3Op  (CallIndirect)
 
                 if (M3_LIKELY(not r))
                 {
+
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+                    r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs, d_m3BaseCstr);
+# else
                     r = Call (function->compiled, sp, _mem, d_m3OpDefaultArgs);
+# endif
+
                     _mem = memory->mallocated;
 
                     if (M3_LIKELY(not r))

--- a/source/m3_exec_defs.h
+++ b/source/m3_exec_defs.h
@@ -21,6 +21,7 @@ d_m3BeginExternC
 # define d_m3BaseOpAllArgs              _pc, _sp, _mem, _r0
 # define d_m3BaseOpDefaultArgs          0
 # define d_m3BaseClearRegisters         _r0 = 0;
+# define d_m3BaseCstr                   ""
 
 # define d_m3ExpOpSig(...)              d_m3BaseOpSig, __VA_ARGS__
 # define d_m3ExpOpArgs(...)             d_m3BaseOpArgs, __VA_ARGS__
@@ -42,18 +43,30 @@ d_m3BeginExternC
 #   define d_m3ClearRegisters       d_m3BaseClearRegisters
 # endif
 
-typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig);
 
 #define d_m3RetSig                  static inline m3ret_t vectorcall
-#define d_m3Op(NAME)                M3_NO_UBSAN d_m3RetSig op_##NAME (d_m3OpSig)
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+    typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig, cstr_t i_operationName);
+#    define d_m3Op(NAME)                M3_NO_UBSAN d_m3RetSig op_##NAME (d_m3OpSig, cstr_t i_operationName)
 
-#define nextOpImpl()                ((IM3Operation)(* _pc))(_pc + 1, d_m3OpArgs)
-#define jumpOpImpl(PC)              ((IM3Operation)(*  PC))( PC + 1, d_m3OpArgs)
+#    define nextOpImpl()            ((IM3Operation)(* _pc))(_pc + 1, d_m3OpArgs, __FUNCTION__)
+#    define jumpOpImpl(PC)          ((IM3Operation)(*  PC))( PC + 1, d_m3OpArgs, __FUNCTION__)
+# else
+    typedef m3ret_t (vectorcall * IM3Operation) (d_m3OpSig);
+#    define d_m3Op(NAME)                M3_NO_UBSAN d_m3RetSig op_##NAME (d_m3OpSig)
+
+#    define nextOpImpl()            ((IM3Operation)(* _pc))(_pc + 1, d_m3OpArgs)
+#    define jumpOpImpl(PC)          ((IM3Operation)(*  PC))( PC + 1, d_m3OpArgs)
+# endif
 
 #define nextOpDirect()              M3_MUSTTAIL return nextOpImpl()
 #define jumpOpDirect(PC)            M3_MUSTTAIL return jumpOpImpl((pc_t)(PC))
 
+# if (d_m3EnableOpProfiling || d_m3EnableOpTracing)
+d_m3RetSig  RunCode  (d_m3OpSig, cstr_t i_operationName)
+# else
 d_m3RetSig  RunCode  (d_m3OpSig)
+# endif
 {
     nextOpDirect();
 }


### PR DESCRIPTION
When `OpProfiling` or `OpTracing` is enabled, wasm3 fails to build with clang-16 because the signature of the function with `__attribute__(musttail)` are incompatible with the calling function.  For instance, the funciton `profileOp` has 6 parameters, but its caller function `RunCode` only has 5. Therefore, to satisfy the requirement of using `__attribute__(musttail)`, I modify function signatures of these functions.
  