### PR TITLE
update to uvwasi 0.0.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ elseif(BUILD_WASI MATCHES "uvwasi")
   FetchContent_Declare(
     uvwasi
     GIT_REPOSITORY https://github.com/nodejs/uvwasi.git
-    GIT_TAG b599542f7ce001e04cdff9db82b05fee96bb3332
+    GIT_TAG 02a7e485a50c61af7d79d4a55a4a2d042e5c1c1c
   )
 
   FetchContent_GetProperties(uvwasi)


### PR DESCRIPTION
This bumps the uvwasi dependency version
from 0.0.12 (Nov 2021) to 0.0.14 (Dec 2022).