### PR TITLE
Draft: start to implement emscripten_return_address for UBSan support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,8 @@
 cmake_minimum_required(VERSION 3.11)
 
+# Enable folder support
+set_property(GLOBAL PROPERTY USE_FOLDERS ON)
+
 # Detect WasiEnv
 if(DEFINED ENV{WASI_CC} OR DEFINED WASI_SDK_PREFIX)
   set(WASIENV           1)
@@ -134,7 +137,7 @@ elseif(WASIENV)
 
 elseif(MSVC OR CMAKE_C_COMPILER_FRONTEND_VARIANT MATCHES "MSVC")
 
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Dd_m3HasTracer -D_CRT_SECURE_NO_WARNINGS /WX- /diagnostics:column")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Dd_m3HasTracer -Dd_m3EnableStrace=2 -Dd_m3RecordBacktraces -Dd_m3HasUBSan -D_CRT_SECURE_NO_WARNINGS /WX- /diagnostics:column")
 
   string(REGEX REPLACE "/W[0-4]" "/W0" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 

--- a/platforms/app/main.c
+++ b/platforms/app/main.c
@@ -84,6 +84,11 @@ M3Result link_all  (IM3Module module)
     if (res) return res;
 #endif
 
+#if defined(d_m3HasUBSan)
+    res = m3_LinkUBSan(module);
+    if (res) return res;
+#endif
+
 #if defined(GAS_LIMIT)
     res = m3_LinkRawFunction (module, "metering", "usegas", "v(i)", &metering_usegas);
     if (!res) {

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -4,6 +4,7 @@ set(sources
     "m3_api_uvwasi.c"
     "m3_api_meta_wasi.c"
     "m3_api_tracer.c"
+    "m3_api_ubsan.c"
     "m3_bind.c"
     "m3_code.c"
     "m3_compile.c"
@@ -16,7 +17,9 @@ set(sources
     "m3_parse.c"
 )
 
-add_library(m3 STATIC ${sources})
+file(GLOB headers "*.h")
+
+add_library(m3 STATIC ${sources} ${headers})
 
 target_include_directories(m3 PUBLIC .)
 

--- a/source/m3_api_ubsan.c
+++ b/source/m3_api_ubsan.c
@@ -1,0 +1,39 @@
+#include "m3_api_ubsan.h"
+
+#include "m3_env.h"
+#include "m3_exception.h"
+
+#if defined(d_m3HasUBSan)
+
+// extern "C" void* emscripten_return_address(int level);
+// https://github.com/quantum5/emscripten/blob/c5fa1768e4826e603bc6158f6b0f26dbdb6d150b/system/lib/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cpp#L86
+m3ApiRawFunction(m3_emscripten_return_address)
+{
+    m3ApiReturnType(uint32_t)
+    m3ApiGetArg(uint32_t, level)
+    m3ApiReturn(1234);
+    //m3ApiTrap(m3Err_trapDivisionByZero);
+}
+
+static
+M3Result  SuppressLookupFailure(M3Result i_result)
+{
+    if (i_result == m3Err_functionLookupFailed)
+        return m3Err_none;
+    else
+        return i_result;
+}
+
+M3Result  m3_LinkUBSan(IM3Module module)
+{
+    M3Result result = m3Err_none;
+
+    const char* env = "env";
+
+_   (SuppressLookupFailure(m3_LinkRawFunction(module, env, "emscripten_return_address", "*(i)", &m3_emscripten_return_address)));
+
+_catch:
+    return result;
+}
+
+#endif // d_m3HasUBSan

--- a/source/m3_api_ubsan.h
+++ b/source/m3_api_ubsan.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifndef m3_api_ubsan_h
+#define m3_api_ubsan_h
+
+#include "m3_core.h"
+
+d_m3BeginExternC
+
+M3Result    m3_LinkUBSan(IM3Module io_module);
+
+d_m3EndExternC
+
+#endif // m3_api_ubsan_h


### PR DESCRIPTION
This isn't really a pull request in the traditional sense, but I figure it will be easier to ask my question this way.

My goal is to compile a WASM executable with emscripten+UBSan (https://emscripten.org/docs/debugging/Sanitizers.html) and then run it in wasm3, showing a backtrace if anything is triggered.

I took the `null-assign.c` from the page:

```c
int main(void) {
    int *a = 0;
    *a = 0;
}
```

Built it with the minimal UBSan runtime:

```sh
emcc null-assign.c -fsanitize=undefined -fsanitize-minimal-runtime -o null-assign.wasm -g
```

And I get [null-assign.wasm](https://github.com/wasm3/wasm3/files/10508144/null-assign.zip).

I figured out that I need to set some preprocessor definitions to enable the call stack and trace output: `-Dd_m3EnableStrace=2 -Dd_m3RecordBacktraces`. Additionally I added my own `-Dd_m3HasUBSan` and implemented a stub `emscripten_return_address` (the function that the UBSan runtime needs).

Everything looks 'fine' from the trace (except obviously the `1234` value for the return address which triggers another check):

```
build\Debug>wasm3 null-assign.wasm
_start () {
  __wasm_call_ctors () {
    emscripten_stack_init () {
    }
  }
  __original_main () {
    __ubsan_handle_type_mismatch_minimal () {
      env!emscripten_return_address(0) { <native> } = 1234
      report_this_error(void*) (i32: 1234) {
      } = 1
      strlen (i32: 65560) {
      } = 21
      write (i32: 2, i32: 65560, i32: 21) {
ubsan: type-mismatch
        wasi_snapshot_preview1!fd_write(2, 65512, 1, 65508) { <native> } = 0
        __wasi_syscall_ret (i32: 0) {
        } = 0
      } = 21
    }
  } = 0
  exit (i32: 0) {
    dummy () {
    }
    libc_exit_fini () {
      dummy () {
      }
    }
    dummy () {
    }
    _Exit (i32: 0) {
      wasi_snapshot_preview1!proc_exit(0) { <native> } -> [trap] program called exit
Assertion failed at D:\CodeBlocks\wasm3\source\m3_core.c:556 : pcFound
```

The issue is at the end, it looks like it is not able to match the PC register back to an offset in the file. Any ideas why? I tried messing with the `emscripten_return_address` function signature but it doesn't appear to make a difference...