### PR TITLE
Disable tail calls on emscripten

### DIFF
--- a/source/m3_config_platforms.h
+++ b/source/m3_config_platforms.h
@@ -82,7 +82,15 @@
 #  endif
 # endif
 
-# if M3_COMPILER_HAS_ATTRIBUTE(musttail)
+# if !defined(M3_HAS_TAIL_CALL)
+#  if defined(__EMSCRIPTEN__)
+#   define M3_HAS_TAIL_CALL 0
+#  else
+#   define M3_HAS_TAIL_CALL 1
+#  endif
+# endif
+
+# if M3_HAS_TAIL_CALL && M3_COMPILER_HAS_ATTRIBUTE(musttail)
 #   define M3_MUSTTAIL __attribute__((musttail))
 # else
 #   define M3_MUSTTAIL


### PR DESCRIPTION
Tail call support for browsers seems experimental. I could only find it implemented in chrome. Firefox still has an open issue https://bugzilla.mozilla.org/show_bug.cgi?id=1571996

This PR disables it by default unless you define `M3_HAS_TAIL_CALL 1` manually