### PR TITLE
Add `m3_GetTableFunction` to allow calling functions by index

### DIFF
--- a/source/m3_env.c
+++ b/source/m3_env.c
@@ -751,6 +751,33 @@ _           (CompileFunction (function))
     return result;
 }
 
+
+M3Result  m3_GetTableFunction  (IM3Function * o_function, IM3Module i_module, uint32_t i_index)
+{
+    M3Result result = m3Err_none;
+
+    if (i_index >= i_module->table0Size)
+    {
+        _throw ("function index out of range");
+    }
+
+    IM3Function function = i_module->table0[i_index];
+
+    if (function)
+    {
+        if (not function->compiled)
+        {
+_           (CompileFunction (function))
+        }
+    }
+
+    * o_function = function;
+
+    _catch:
+    return result;
+}
+
+
 static
 M3Result checkStartFunction(IM3Module i_module)
 {

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -291,6 +291,9 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
     M3Result            m3_FindFunction             (IM3Function *          o_function,
                                                      IM3Runtime             i_runtime,
                                                      const char * const     i_functionName);
+    M3Result            m3_GetTableFunction         (IM3Function *          o_function,
+                                                     IM3Module              i_module,
+                                                     uint32_t               i_index);
 
     uint32_t            m3_GetArgCount              (IM3Function i_function);
     uint32_t            m3_GetRetCount              (IM3Function i_function);


### PR DESCRIPTION
Resolves #101.

Rather than directly invoking functions by their index, this just allows `IM3Function` instances to be obtained by index, so they can then be called with the standard call functions.