### PR TITLE
Allow for retrieval of "memory" type import / export name

### DIFF
--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -110,6 +110,7 @@ typedef struct M3Module
 
     IM3Function *           table0;
     u32                     table0Size;
+    const char*             table0ExportName;
 
     M3MemoryInfo            memoryInfo;
     M3ImportInfo            memoryImport;

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -112,6 +112,7 @@ typedef struct M3Module
     u32                     table0Size;
 
     M3MemoryInfo            memoryInfo;
+    M3ImportInfo            memoryImport;
     bool                    memoryImported;
     const char*             memoryExportName;
 

--- a/source/m3_env.h
+++ b/source/m3_env.h
@@ -113,6 +113,7 @@ typedef struct M3Module
 
     M3MemoryInfo            memoryInfo;
     bool                    memoryImported;
+    const char*             memoryExportName;
 
     //bool                    hasWasmCodeCopy;
 

--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -256,6 +256,12 @@ _       (ReadLEB_u32 (& index, & i_bytes, i_end));                              
             global->name = utf8;
             utf8 = NULL; // ownership transferred to M3Global
         }
+        else if (exportKind == d_externalKind_memory)
+        {
+            m3_Free (io_module->memoryExportName);
+            io_module->memoryExportName = utf8;
+            utf8 = NULL; // ownership transferred to M3Module
+        }
 
         m3_Free (utf8);
     }

--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -184,6 +184,8 @@ _               (Module_AddFunction (io_module, typeIndex, & import))
             {
 _               (ParseType_Memory (& io_module->memoryInfo, & i_bytes, i_end));
                 io_module->memoryImported = true;
+                io_module->memoryImport = import;
+                import = clearImport;
             }
             break;
 

--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -264,6 +264,12 @@ _       (ReadLEB_u32 (& index, & i_bytes, i_end));                              
             io_module->memoryExportName = utf8;
             utf8 = NULL; // ownership transferred to M3Module
         }
+        else if (exportKind == d_externalKind_table)
+        {
+            m3_Free (io_module->table0ExportName);
+            io_module->table0ExportName = utf8;
+            utf8 = NULL; // ownership transferred to M3Module
+        }
 
         m3_Free (utf8);
     }


### PR DESCRIPTION
Adds a `module->memoryImport` (for import module/field names), and `module->memoryExportName` (for exported name) fields to the `M3Module` struct, and populates those values when appropriate during `m3_ParseModule()`.

Somewhat related to #110 and #137.