### PR TITLE
bugfix: use gcc/clang compatible overflow builtins for integer arithmetic

### DIFF
--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -149,8 +149,9 @@ d_m3CommutativeOpMacro(RES, REG, TYPE,NAME, OP, ##__VA_ARGS__)
 #define d_m3CommutativeOpMacro_f(TYPE, NAME, MACRO, ...)    d_m3CommutativeOpMacro  (_fp0, _fp0, TYPE, NAME, MACRO, ##__VA_ARGS__)
 #define d_m3OpMacro_f(TYPE, NAME, MACRO, ...)               d_m3OpMacro             (_fp0, _fp0, TYPE, NAME, MACRO, ##__VA_ARGS__)
 
-#define M3_FUNC(RES, A, B, OP)  (RES) = OP((A), (B))    // Accept functions: res = OP(a,b)
-#define M3_OPER(RES, A, B, OP)  (RES) = ((A) OP (B))    // Accept operators: res = a OP b
+#define M3_FUNC(RES, A, B, OP)  (RES) = OP((A), (B))        // Accept functions: res = OP(a,b)
+#define M3_OPER(RES, A, B, OP)  (RES) = ((A) OP (B))        // Accept operators: res = a OP b
+#define M3_OFOP(RES, A, B, OP)  (void)OP((A), (B), &(RES))  // Accept builtins: OP(a, b, &res)
 
 #define d_m3CommutativeOpFunc_i(TYPE, NAME, OP)     d_m3CommutativeOpMacro_i    (TYPE, NAME, M3_FUNC, OP)
 #define d_m3OpFunc_i(TYPE, NAME, OP)                d_m3OpMacro_i               (TYPE, NAME, M3_FUNC, OP)
@@ -161,6 +162,9 @@ d_m3CommutativeOpMacro(RES, REG, TYPE,NAME, OP, ##__VA_ARGS__)
 #define d_m3Op_i(TYPE, NAME, OP)                    d_m3OpMacro_i               (TYPE, NAME, M3_OPER, OP)
 #define d_m3CommutativeOp_f(TYPE, NAME, OP)         d_m3CommutativeOpMacro_f    (TYPE, NAME, M3_OPER, OP)
 #define d_m3Op_f(TYPE, NAME, OP)                    d_m3OpMacro_f               (TYPE, NAME, M3_OPER, OP)
+
+#define d_m3CommutativeOverflowOp_i(TYPE, NAME, OP) d_m3CommutativeOpMacro_i    (TYPE, NAME, M3_OFOP, OP)
+#define d_m3OverflowOp_i(TYPE, NAME, OP)            d_m3OpMacro_i               (TYPE, NAME, M3_OFOP, OP)
 
 // compare needs to be distinct for fp 'cause the result must be _r0
 #define d_m3CompareOp_f(TYPE, NAME, OP)             d_m3OpMacro                 (_r0, _fp0, TYPE, NAME, M3_OPER, OP)
@@ -193,10 +197,18 @@ d_m3CompareOp_f (f32, LessThanOrEqual,      <=)     d_m3CompareOp_f (f64, LessTh
 d_m3CompareOp_f (f32, GreaterThanOrEqual,   >=)     d_m3CompareOp_f (f64, GreaterThanOrEqual,   >=)
 #endif
 
-d_m3CommutativeOp_i (i32, Add,              +)      d_m3CommutativeOp_i (i64, Add,              +)
-d_m3CommutativeOp_i (i32, Multiply,         *)      d_m3CommutativeOp_i (i64, Multiply,         *)
+// d_m3CommutativeOp_i (i32, Add,              +)      d_m3CommutativeOp_i (i64, Add,              +)
+// d_m3CommutativeOp_i (i32, Multiply,         *)      d_m3CommutativeOp_i (i64, Multiply,         *)
 
-d_m3Op_i (i32, Subtract,                    -)      d_m3Op_i (i64, Subtract,                    -)
+// d_m3Op_i (i32, Subtract,                    -)      d_m3Op_i (i64, Subtract,                    -)
+
+d_m3CommutativeOverflowOp_i (i32, Add,      __builtin_add_overflow)
+d_m3CommutativeOverflowOp_i (i64, Add,      __builtin_add_overflow)
+d_m3CommutativeOverflowOp_i (i32, Multiply, __builtin_mul_overflow)
+d_m3CommutativeOverflowOp_i (i64, Multiply, __builtin_mul_overflow)
+
+d_m3OverflowOp_i            (i32, Subtract, __builtin_sub_overflow)
+d_m3OverflowOp_i            (i64, Subtract, __builtin_sub_overflow)
 
 #define OP_SHL_32(X,N) ((X) << ((u32)(N) % 32))
 #define OP_SHL_64(X,N) ((X) << ((u64)(N) % 64))

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -154,7 +154,6 @@ d_m3CommutativeOpMacro(RES, REG, TYPE,NAME, OP, ##__VA_ARGS__)
 
 #define M3_FUNC(RES, A, B, OP)  (RES) = OP((A), (B))        // Accept functions: res = OP(a,b)
 #define M3_OPER(RES, A, B, OP)  (RES) = ((A) OP (B))        // Accept operators: res = a OP b
-#define M3_OFOP(RES, A, B, OP)  (void)OP((A), (B), &(RES))  // Accept builtins: OP(a, b, &res)
 
 #define d_m3CommutativeOpFunc_i(TYPE, NAME, OP)     d_m3CommutativeOpMacro_i    (TYPE, NAME, M3_FUNC, OP)
 #define d_m3OpFunc_i(TYPE, NAME, OP)                d_m3OpMacro_i               (TYPE, NAME, M3_FUNC, OP)
@@ -165,9 +164,6 @@ d_m3CommutativeOpMacro(RES, REG, TYPE,NAME, OP, ##__VA_ARGS__)
 #define d_m3Op_i(TYPE, NAME, OP)                    d_m3OpMacro_i               (TYPE, NAME, M3_OPER, OP)
 #define d_m3CommutativeOp_f(TYPE, NAME, OP)         d_m3CommutativeOpMacro_f    (TYPE, NAME, M3_OPER, OP)
 #define d_m3Op_f(TYPE, NAME, OP)                    d_m3OpMacro_f               (TYPE, NAME, M3_OPER, OP)
-
-#define d_m3CommutativeOverflowOp_i(TYPE, NAME, OP) d_m3CommutativeOpMacro_i    (TYPE, NAME, M3_OFOP, OP)
-#define d_m3OverflowOp_i(TYPE, NAME, OP)            d_m3OpMacro_i               (TYPE, NAME, M3_OFOP, OP)
 
 // compare needs to be distinct for fp 'cause the result must be _r0
 #define d_m3CompareOp_f(TYPE, NAME, OP)             d_m3OpMacro                 (_r0, _fp0, TYPE, NAME, M3_OPER, OP)
@@ -200,17 +196,17 @@ d_m3CompareOp_f (f32, LessThanOrEqual,      <=)     d_m3CompareOp_f (f64, LessTh
 d_m3CompareOp_f (f32, GreaterThanOrEqual,   >=)     d_m3CompareOp_f (f64, GreaterThanOrEqual,   >=)
 #endif
 
-#if defined(M3_COMPILER_GCC) || defined(M3_COMPILER_CLANG)
-d_m3CommutativeOverflowOp_i (i32, Add,      __builtin_add_overflow) d_m3CommutativeOverflowOp_i (i64, Add,      __builtin_add_overflow)
-d_m3CommutativeOverflowOp_i (i32, Multiply, __builtin_mul_overflow) d_m3CommutativeOverflowOp_i (i64, Multiply, __builtin_mul_overflow)
+#define OP_ADD_32(A,B) (i32)((u32)(A) + (u32)(B))
+#define OP_ADD_64(A,B) (i64)((u64)(A) + (u64)(B))
+#define OP_SUB_32(A,B) (i32)((u32)(A) - (u32)(B))
+#define OP_SUB_64(A,B) (i64)((u64)(A) - (u64)(B))
+#define OP_MUL_32(A,B) (i32)((u32)(A) * (u32)(B))
+#define OP_MUL_64(A,B) (i64)((u64)(A) * (u64)(B))
 
-d_m3OverflowOp_i            (i32, Subtract, __builtin_sub_overflow) d_m3OverflowOp_i            (i64, Subtract, __builtin_sub_overflow)
-#else
-d_m3CommutativeOp_i (i32, Add,              +)      d_m3CommutativeOp_i (i64, Add,              +)
-d_m3CommutativeOp_i (i32, Multiply,         *)      d_m3CommutativeOp_i (i64, Multiply,         *)
+d_m3CommutativeOpFunc_i (i32, Add,      OP_ADD_32)  d_m3CommutativeOpFunc_i (i64, Add,      OP_ADD_64)
+d_m3CommutativeOpFunc_i (i32, Multiply, OP_MUL_32)  d_m3CommutativeOpFunc_i (i64, Multiply, OP_MUL_64)
 
-d_m3Op_i (i32, Subtract,                    -)      d_m3Op_i (i64, Subtract,                    -)
-#endif
+d_m3OpFunc_i (i32, Subtract,            OP_SUB_32)  d_m3OpFunc_i (i64, Subtract,            OP_SUB_64)
 
 #define OP_SHL_32(X,N) ((X) << ((u32)(N) % 32))
 #define OP_SHL_64(X,N) ((X) << ((u64)(N) % 64))

--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -200,18 +200,17 @@ d_m3CompareOp_f (f32, LessThanOrEqual,      <=)     d_m3CompareOp_f (f64, LessTh
 d_m3CompareOp_f (f32, GreaterThanOrEqual,   >=)     d_m3CompareOp_f (f64, GreaterThanOrEqual,   >=)
 #endif
 
-// d_m3CommutativeOp_i (i32, Add,              +)      d_m3CommutativeOp_i (i64, Add,              +)
-// d_m3CommutativeOp_i (i32, Multiply,         *)      d_m3CommutativeOp_i (i64, Multiply,         *)
+#if defined(M3_COMPILER_GCC) || defined(M3_COMPILER_CLANG)
+d_m3CommutativeOverflowOp_i (i32, Add,      __builtin_add_overflow) d_m3CommutativeOverflowOp_i (i64, Add,      __builtin_add_overflow)
+d_m3CommutativeOverflowOp_i (i32, Multiply, __builtin_mul_overflow) d_m3CommutativeOverflowOp_i (i64, Multiply, __builtin_mul_overflow)
 
-// d_m3Op_i (i32, Subtract,                    -)      d_m3Op_i (i64, Subtract,                    -)
+d_m3OverflowOp_i            (i32, Subtract, __builtin_sub_overflow) d_m3OverflowOp_i            (i64, Subtract, __builtin_sub_overflow)
+#else
+d_m3CommutativeOp_i (i32, Add,              +)      d_m3CommutativeOp_i (i64, Add,              +)
+d_m3CommutativeOp_i (i32, Multiply,         *)      d_m3CommutativeOp_i (i64, Multiply,         *)
 
-d_m3CommutativeOverflowOp_i (i32, Add,      __builtin_add_overflow)
-d_m3CommutativeOverflowOp_i (i64, Add,      __builtin_add_overflow)
-d_m3CommutativeOverflowOp_i (i32, Multiply, __builtin_mul_overflow)
-d_m3CommutativeOverflowOp_i (i64, Multiply, __builtin_mul_overflow)
-
-d_m3OverflowOp_i            (i32, Subtract, __builtin_sub_overflow)
-d_m3OverflowOp_i            (i64, Subtract, __builtin_sub_overflow)
+d_m3Op_i (i32, Subtract,                    -)      d_m3Op_i (i64, Subtract,                    -)
+#endif
 
 #define OP_SHL_32(X,N) ((X) << ((u32)(N) % 32))
 #define OP_SHL_64(X,N) ((X) << ((u64)(N) % 64))


### PR DESCRIPTION
[as the spec states](https://webassembly.github.io/spec/core/exec/numerics.html#op-iadd) integer add, sub, and mul should wrap on overflow.

the current implementation adds two signed integers, which is undefined behavior on overflow per the C standard (in my case, this triggered an `illegal execution`). this bugfix uses __builtin_add_overflow (and mul, sub variants) to make this behavior well defined.