### PR TITLE
Fix: support special wasm function name

### DIFF
--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -250,12 +250,18 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
     // Placeholder return value slots are first and arguments after. So, the first argument is at _sp [numReturns]
     // Return values should be written into _sp [0] to _sp [num_returns - 1]
     typedef const void * (* M3RawCall) (IM3Runtime runtime, IM3ImportContext _ctx, uint64_t * _sp, void * _mem);
-
+    typedef const int (* M3LinkFuncBlock)(const char *, const char *);
     M3Result            m3_LinkRawFunction          (IM3Module              io_module,
                                                      const char * const     i_moduleName,
                                                      const char * const     i_functionName,
                                                      const char * const     i_signature,
                                                      M3RawCall              i_function);
+    M3Result            m3_LinkRawFunctionBlock     (IM3Module              io_module,
+                                                     const char * const     i_moduleName,
+                                                     const char * const     i_functionName,
+                                                     const char * const     i_signature,
+                                                     M3RawCall              i_function,
+                                                     M3LinkFuncBlock        block);
 
     M3Result            m3_LinkRawFunctionEx        (IM3Module              io_module,
                                                      const char * const     i_moduleName,


### PR DESCRIPTION
Write wasm using rust with wasm-pack and wasm-bindgen tools. But wasm-bindgen will rename export function name using  shorthash.

for example:

```
#[wasm_bindgen]
extern "C" {
    fn alert();
}

```

this code will rename like this in wasm: `  (func $import0 (import "wbg" "__wbg_alert_2de8bdec59d2582f"))`

I don't know exactly all the export function names. 
Pull this request to support find import name with custom function callback.