### PR TITLE
Implement faster* BE ABI

### DIFF
--- a/source/m3_exec.h
+++ b/source/m3_exec.h
@@ -729,8 +729,13 @@ d_m3Op  (MemCopy)
     {
         if (M3_LIKELY(source + size <= _mem->length))
         {
+#if defined(M3_BIG_ENDIAN) && defined(M3_WASM2C_ABI)
+            u8 * dst = m3MemData (_mem) + (_mem->length - destination - size);
+            u8 * src = m3MemData (_mem) + (_mem->length - source - size);
+#else
             u8 * dst = m3MemData (_mem) + destination;
             u8 * src = m3MemData (_mem) + source;
+#endif
             memmove (dst, src, size);
 
             nextOp ();
@@ -749,7 +754,11 @@ d_m3Op  (MemFill)
 
     if (M3_LIKELY(destination + size <= _mem->length))
     {
+#if defined(M3_BIG_ENDIAN) && defined(M3_WASM2C_ABI)
+        u8 * mem8 = m3MemData (_mem) + (_mem->length - destination - size);
+#else
         u8 * mem8 = m3MemData (_mem) + destination;
+#endif
         memset (mem8, (u8) byte, size);
         nextOp ();
     }
@@ -1305,6 +1314,7 @@ d_m3Op  (SetGlobal_f64)
 
 // memcpy here is to support non-aligned access on some platforms.
 
+#if !defined(M3_BIG_ENDIAN) || !defined(M3_WASM2C_ABI)
 #define d_m3Load(REG,DEST_TYPE,SRC_TYPE)                \
 d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_r)                 \
 {                                                       \
@@ -1349,6 +1359,50 @@ d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_s)                 \
     } else d_outOfBounds;                               \
 }
 
+#else
+#define d_m3Load(REG,DEST_TYPE,SRC_TYPE)                \
+d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_r)                 \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u32 offset = immediate (u32);                       \
+    u64 operand = (u32) _r0;                            \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (SRC_TYPE) <= _mem->length     \
+    )) {                                                \
+        {                                               \
+            u8* src8 = m3MemData(_mem) + (_mem->length - operand - sizeof (SRC_TYPE));       \
+            SRC_TYPE value;                             \
+            memcpy(&value, src8, sizeof(value));        \
+            REG = (DEST_TYPE)value;                     \
+            d_m3TraceLoad(DEST_TYPE, operand, REG);     \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}                                                       \
+d_m3Op(DEST_TYPE##_Load_##SRC_TYPE##_s)                 \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u64 operand = slot (u32);                           \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (SRC_TYPE) <= _mem->length     \
+    )) {                                                \
+        {                                               \
+            u8* src8 = m3MemData(_mem) + (_mem->length - operand - sizeof (SRC_TYPE));       \
+            SRC_TYPE value;                             \
+            memcpy(&value, src8, sizeof(value));        \
+            REG = (DEST_TYPE)value;                     \
+            d_m3TraceLoad(DEST_TYPE, operand, REG);     \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}
+#endif
+
 //  printf ("get: %d -> %d\n", operand + offset, (i64) REG);
 
 
@@ -1374,6 +1428,7 @@ d_m3Load_i (i64, i32);
 d_m3Load_i (i64, u32);
 d_m3Load_i (i64, i64);
 
+#if !defined(M3_BIG_ENDIAN) || !defined(M3_WASM2C_ABI)
 #define d_m3Store(REG, SRC_TYPE, DEST_TYPE)             \
 d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_rs)             \
 {                                                       \
@@ -1460,6 +1515,91 @@ d_m3Op  (TYPE##_Store_##TYPE##_rr)                      \
         nextOp ();                                      \
     } else d_outOfBounds;                               \
 }
+
+#else
+#define d_m3Store(REG, SRC_TYPE, DEST_TYPE)             \
+d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_rs)             \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u64 operand = slot (u32);                           \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (DEST_TYPE) <= _mem->length    \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, REG);     \
+            u8* mem8 = m3MemData(_mem) + (_mem->length - operand - sizeof (DEST_TYPE));       \
+            DEST_TYPE val = (DEST_TYPE) REG;            \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}                                                       \
+d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_sr)             \
+{                                                       \
+    d_m3TracePrepare                                    \
+    const SRC_TYPE value = slot (SRC_TYPE);             \
+    u64 operand = (u32) _r0;                            \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (DEST_TYPE) <= _mem->length    \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, value);   \
+            u8* mem8 = m3MemData(_mem) + (_mem->length - operand - sizeof (DEST_TYPE));       \
+            DEST_TYPE val = (DEST_TYPE) value;          \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}                                                       \
+d_m3Op  (SRC_TYPE##_Store_##DEST_TYPE##_ss)             \
+{                                                       \
+    d_m3TracePrepare                                    \
+    const SRC_TYPE value = slot (SRC_TYPE);             \
+    u64 operand = slot (u32);                           \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (DEST_TYPE) <= _mem->length    \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(SRC_TYPE, operand, value);   \
+            u8* mem8 = m3MemData(_mem) + (_mem->length - operand - sizeof (DEST_TYPE));       \
+            DEST_TYPE val = (DEST_TYPE) value;          \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}
+
+// both operands can be in regs when storing a float
+#define d_m3StoreFp(REG, TYPE)                          \
+d_m3Op  (TYPE##_Store_##TYPE##_rr)                      \
+{                                                       \
+    d_m3TracePrepare                                    \
+    u64 operand = (u32) _r0;                            \
+    u32 offset = immediate (u32);                       \
+    operand += offset;                                  \
+                                                        \
+    if (m3MemCheck(                                     \
+        operand + sizeof (TYPE) <= _mem->length         \
+    )) {                                                \
+        {                                               \
+            d_m3TraceStore(TYPE, operand, REG);         \
+            u8* mem8 = m3MemData(_mem) + (_mem->length - operand - sizeof (TYPE));       \
+            TYPE val = (TYPE) REG;                      \
+            memcpy(mem8, &val, sizeof(val));            \
+        }                                               \
+        nextOp ();                                      \
+    } else d_outOfBounds;                               \
+}
+#endif
 
 
 #define d_m3Store_i(SRC_TYPE, DEST_TYPE) d_m3Store(_r0, SRC_TYPE, DEST_TYPE)

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -331,8 +331,13 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 //  raw function definition helpers
 //-------------------------------------------------------------------------------------------------------------------------------
 
+# if !defined(M3_BIG_ENDIAN) || !defined(M3_WASM2C_ABI)
 # define m3ApiOffsetToPtr(offset)   (void*)((uint8_t*)_mem + (uint32_t)(offset))
 # define m3ApiPtrToOffset(ptr)      (uint32_t)((uint8_t*)ptr - (uint8_t*)_mem)
+# else
+# define m3ApiOffsetToPtr(offset)   (void*)((uint8_t*)_mem + (uint32_t)(m3_GetMemorySize(runtime)-(offset)))
+# define m3ApiPtrToOffset(ptr)      (uint32_t)(m3_GetMemorySize(runtime)-((uint8_t*)ptr - (uint8_t*)_mem))
+# endif
 
 # define m3ApiReturnType(TYPE)                 TYPE* raw_return = ((TYPE*) (_sp++));
 # define m3ApiMultiValueReturnType(TYPE, NAME) TYPE* NAME = ((TYPE*) (_sp++));
@@ -348,7 +353,7 @@ d_m3ErrorConst  (trapStackOverflow,             "[trap] stack overflow")
 # define m3ApiTrap(VALUE)                     { return VALUE; }
 # define m3ApiSuccess()                       { return m3Err_none; }
 
-# if defined(M3_BIG_ENDIAN)
+# if defined(M3_BIG_ENDIAN) && !defined(M3_WASM2C_ABI)
 #  define m3ApiReadMem8(ptr)         (* (uint8_t *)(ptr))
 #  define m3ApiReadMem16(ptr)        m3_bswap16((* (uint16_t *)(ptr)))
 #  define m3ApiReadMem32(ptr)        m3_bswap32((* (uint32_t *)(ptr)))


### PR DESCRIPTION
We wanted to make wasm3 faster for compute-heavy workloads on big-endian platforms. We can do this by changing the ABI.

Notes: wasi implementation has not been updated for this ABI (wasi tests fail completely), CI has not been updated to run any tests for this ABI but spec tests pass locally.