### PR TITLE
Include missing stddef.h in wasm3.h

### DIFF
--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -17,6 +17,7 @@
 #include <stdint.h>
 #include <inttypes.h>
 #include <stdarg.h>
+#include <stddef.h>
 
 #include "wasm3_defs.h"
 


### PR DESCRIPTION
`stddef.h` is needed for `NULL`