### PR TITLE
zig build: updated to v0.13.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 .settings
 .vscode
 .DS_Store
+*zig-*/

--- a/build.zig
+++ b/build.zig
@@ -1,39 +1,84 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) !void {
+pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
-    const mode = b.standardReleaseOptions();
+    const optimize = b.standardOptimizeOption(.{});
 
-    const wasm3 = b.addExecutable("wasm3", null);
-    wasm3.setTarget(target);
-    wasm3.setBuildMode(mode);
-    wasm3.install();
-    wasm3.linkLibC();
+    const libm3_only = b.option(bool, "libm3", "Build libwasm3 only") orelse false;
 
-    if (target.getCpuArch() == .wasm32 and target.getOsTag() == .wasi) {
-        wasm3.linkSystemLibrary("wasi-emulated-process-clocks");
-    }
-
-    wasm3.addIncludePath("source");
-    wasm3.addCSourceFiles(&.{
-        "source/m3_api_libc.c",
-        "source/m3_api_meta_wasi.c",
-        "source/m3_api_tracer.c",
-        "source/m3_api_uvwasi.c",
-        "source/m3_api_wasi.c",
-        "source/m3_bind.c",
-        "source/m3_code.c",
-        "source/m3_compile.c",
-        "source/m3_core.c",
-        "source/m3_env.c",
-        "source/m3_exec.c",
-        "source/m3_function.c",
-        "source/m3_info.c",
-        "source/m3_module.c",
-        "source/m3_parse.c",
-        "platforms/app/main.c",
-    }, &.{
-        "-Dd_m3HasWASI",
-        "-fno-sanitize=undefined", // TODO investigate UB sites in the codebase, then delete this line.
+    const libwasm3 = b.addStaticLibrary(.{
+        .name = "m3",
+        .target = target,
+        .optimize = optimize,
     });
+    libwasm3.root_module.sanitize_c = false; // fno-sanitize=undefined
+    libwasm3.defineCMacro("d_m3HasTracer", null);
+
+    if (libwasm3.rootModuleTarget().isWasm()) {
+        if (libwasm3.rootModuleTarget().os.tag == .wasi) {
+            libwasm3.defineCMacro("d_m3HasWASI", null);
+            libwasm3.linkSystemLibrary("wasi-emulated-process-clocks");
+        }
+    }
+    libwasm3.addIncludePath(b.path("source"));
+    libwasm3.addCSourceFiles(.{
+        .files = &.{
+            "source/m3_api_libc.c",
+            "source/extensions/m3_extensions.c",
+            "source/m3_api_meta_wasi.c",
+            "source/m3_api_tracer.c",
+            "source/m3_api_uvwasi.c",
+            "source/m3_api_wasi.c",
+            "source/m3_bind.c",
+            "source/m3_code.c",
+            "source/m3_compile.c",
+            "source/m3_core.c",
+            "source/m3_env.c",
+            "source/m3_exec.c",
+            "source/m3_function.c",
+            "source/m3_info.c",
+            "source/m3_module.c",
+            "source/m3_parse.c",
+        },
+        .flags = if (libwasm3.rootModuleTarget().isWasm())
+            &cflags ++ [_][]const u8{
+                "-Xclang",
+                "-target-feature",
+                "-Xclang",
+                "+tail-call",
+            }
+        else
+            &cflags,
+    });
+    libwasm3.linkSystemLibrary("m");
+    libwasm3.linkLibC();
+
+    if (!libm3_only) {
+        const wasm3 = b.addExecutable(.{
+            .name = "wasm3",
+            .target = target,
+            .optimize = optimize,
+        });
+        for (libwasm3.root_module.include_dirs.items) |dir| {
+            wasm3.addIncludePath(dir.path);
+        }
+        wasm3.addCSourceFile(.{
+            .file = .{ .cwd_relative = "platforms/app/main.c" },
+            .flags = &cflags,
+        });
+
+        wasm3.linkLibrary(libwasm3);
+        b.installArtifact(wasm3);
+    } else b.installArtifact(libwasm3);
 }
+
+const cflags = [_][]const u8{
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wparentheses",
+    "-Wundef",
+    "-Wpointer-arith",
+    "-Wstrict-aliasing=2",
+    "-std=gnu11",
+};


### PR DESCRIPTION
https://ziglang.org/download/0.13.0/release-notes.html

changes:

- update zig version
- switch between build libwasm3 only or wasm3+libwasm3 (since v0.11.0, help zig-pkg manager [a.k.a zon-file])

e.g.: https://github.com/kassane/wasm3-d/blob/main/build.zig.zon

close #454 

cc: @vshymanskyy 