### PR TITLE
Fix Global Buffer Overflow on "PreserveRegisterIfOccupied" Function

### DIFF
--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -489,7 +489,12 @@ M3Result  PreserveRegisterIfOccupied  (IM3Compilation o, u8 i_registerType)
 _       (AllocateSlots (o, & slot, type));
         o->wasmStack [stackIndex] = slot;
 
-_       (EmitOp (o, c_setSetOps [type]));
+        // Ensure type is within the valid range
+        if (type < sizeof(c_setSetOps) / sizeof(c_setSetOps[0])) {
+_           (EmitOp (o, c_setSetOps [type]));
+        } else 
+            _throw(m3Err_functionStackOverflow);
+
         EmitSlotOffset (o, slot);
     }
 


### PR DESCRIPTION
Fix https://github.com/wasm3/wasm3/issues/483

This patch ensures that the `type` variable is within the valid range before using it as an index to access the `c_setSetOps` array, thus preventing the global-buffer-overflow error.