### PR TITLE
Add m3_LinkRawTableFunction to extensions

### DIFF
--- a/source/extensions/wasm3_ext.h
+++ b/source/extensions/wasm3_ext.h
@@ -44,6 +44,17 @@ extern "C" {
     IM3Function         m3_GetFunctionByIndex       (IM3Module              i_module,
                                                      uint32_t               i_index);
 
+    M3Result            m3_LinkRawTableFunction     (IM3Module              io_module,
+                                                     uint32_t               index,
+                                                     const char * const     i_signature,
+                                                     M3RawCall              i_function);
+
+    M3Result            m3_LinkRawTableFunctionEx   (IM3Module              io_module,
+                                                     uint32_t               index,
+                                                     const char * const     i_signature,
+                                                     M3RawCall              i_function,
+                                                     const void *           i_userdata);
+
 #if defined(__cplusplus)
 }
 #endif


### PR DESCRIPTION
A common way to pass a callback into as wasm program is to insert the callback into the indirect function call table. (See library_addfunction.js from emscripten).

In javascript, the type of the function doesnt need to be specified, call_indirect will always just work on the index if its an external function (assuming the table is type anyfunc). Wasm3 calls raw functiosn via a wasm trampoline so here we need to pass a function sig for the trampoline.