### PR TITLE
Added type check to index var for br_table

### DIFF
--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -1532,6 +1532,10 @@ static
 M3Result  Compile_BranchTable  (IM3Compilation o, m3opcode_t i_opcode)
 {
 _try {
+    if (o->typeStack[0] != c_m3Type_i32)
+    {
+        _throw ( ErrorCompile (m3Err_globalTypeMismatch, o, "br_table index not i32") );
+    }
     u32 targetCount;
 _   (ReadLEB_u32 (& targetCount, & o->wasm, o->wasmEnd));
 
@@ -1551,7 +1555,6 @@ _   (EmitOp (o, op_BranchTable));
     EmitConstant32 (o, targetCount);
 
     IM3CodePage continueOpPage = NULL;
-
     ++targetCount; // include default
     for (u32 i = 0; i < targetCount; ++i)
     {


### PR DESCRIPTION
This causes a bunch of the tests to fail, though.

I went through and messed with the JSON to just simply convert any function that relies on passing any non-i32 value to br_table, from expecting values, to expecting the error. I'd like to speak with someone before making another pr on the testsuite archive repo that the python script pulls from.

However, I'm not very comfortable with the codebase, and I'm not able to dedicate an extreme amount of time to understand it further. So I'd like someone more familiar with the codebase to look and see if my error checking is done in the right place and on the right thing, and I'd also appreciate some advice and helping checking/fixing the json testing

edit: This should fix #519 