### PR TITLE
fix: crash in app/main.c strrchr

### DIFF
--- a/platforms/app/main.c
+++ b/platforms/app/main.c
@@ -101,8 +101,8 @@ const char* modname_from_fn(const char* fn)
     const char* sep = "/\\:*?";
     char c;
     while ((c = *sep++)) {
-        const char* off = strrchr(fn, c) + 1;
-        fn = (fn < off) ? off : fn;
+        const char* off = strrchr(fn, c);
+        fn = (off && fn < off+1) ? off+1 : fn;
     }
     return fn;
 }


### PR DESCRIPTION
## Summary

Fixes crash when running on MacOS like this:

```bash
./wasm3 test/regression/github-442.wasm
```

I get the following crash:

```bash
./build.sh: line 1: 50729 Trace/BPT trap: 5       ./wasm3 test/regression/github-442.wasm
```

Full backtrace with lldb:

```bash
nick:~/dev/wasm3 79d412e* lldb wasm3
(lldb) target create "wasm3"
Current executable set to '/Users/nick/dev/wasm3/wasm3' (arm64).
(lldb) run test/regression/github-442.wasm
Process 50756 launched: '/Users/nick/dev/wasm3/wasm3' (arm64)
Process 50756 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1000272f8)
    frame #0: 0x00000001000272f8 wasm3`modname_from_fn(fn="github-442.wasm") at main.c:104:42
   101 	    const char* sep = "/\\:*?";
   102 	    char c;
   103 	    while ((c = *sep++)) {
-> 104 	        const char* off = strrchr(fn, c) + 1;
   105 	        fn = (fn < off) ? off : fn;
   106 	    }
   107 	    return fn;
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BREAKPOINT (code=1, subcode=0x1000272f8)
  * frame #0: 0x00000001000272f8 wasm3`modname_from_fn(fn="github-442.wasm") at main.c:104:42
    frame #1: 0x0000000100027510 wasm3`repl_load(fn="test/regression/github-442.wasm") at main.c:153:30
    frame #2: 0x000000010002b020 wasm3`main(i_argc=0, i_argv=0x000000016fdff230) at main.c:627:18
    frame #3: 0x00000001919d7f28 dyld`start + 2236
```

According to the docs on [`strrchr`](https://cplusplus.com/reference/cstring/strrchr/):

> If the character is not found, the function returns a null pointer.

This fix adds a check for NULL.

## System Info

```bash
ProductName:		macOS
ProductVersion:		13.5
BuildVersion:		22G74
```

```bash
Darwin Nicks-MacBook-Air.local 22.6.0 Darwin Kernel Version 22.6.0: Wed Jul  5 22:17:35 PDT 2023; root:xnu-8796.141.3~6/RELEASE_ARM64_T8112 arm64
```