### PR TITLE
Fix #510: Correct memory section vFix #510: Correct memory section validationalidation

### DIFF
--- a/source/m3_parse.c
+++ b/source/m3_parse.c
@@ -457,7 +457,7 @@ M3Result  ParseSection_Memory  (M3Module * io_module, bytes_t i_bytes, cbytes_t 
     u32 numMemories;
 _   (ReadLEB_u32 (& numMemories, & i_bytes, i_end));                             m3log (parse, "** Memory [%d]", numMemories);
 
-    _throwif (m3Err_tooManyMemorySections, numMemories != 1);
+    _throwif (m3Err_tooManyMemorySections, numMemories > 1);
 
     ParseType_Memory (& io_module->memoryInfo, & i_bytes, i_end);
 


### PR DESCRIPTION
## Description
Fixes issue #510 where the memory number check was incorrect.

## Changes
- Changed validation check from `numMemories != 1` to `numMemories > 1` in `source/m3_parse.c` line 460
- This allows modules with 0 or 1 memory sections, as per WebAssembly 1.0 specification
- Previously, modules with 0 memories were incorrectly rejected

## Testing
- Code compiles successfully
- Change allows valid WASM modules with 0 or 1 memory sections
- Still correctly rejects modules with 2+ memory sections

Fixes #510