### PR TITLE
Fix #505: Remove undefined behavior in modname_from_fn

### DIFF
--- a/platforms/app/main.c
+++ b/platforms/app/main.c
@@ -101,8 +101,8 @@ const char* modname_from_fn(const char* fn)
     const char* sep = "/\\:*?";
     char c;
     while ((c = *sep++)) {
-        const char* off = strrchr(fn, c) + 1;
-        fn = (fn < off) ? off : fn;
+        const char* off = strrchr(fn, c);
+        fn = off ? off + 1 : fn;
     }
     return fn;
 }


### PR DESCRIPTION
## Description
Fixes issue #505 - undefined behavior in the `modname_from_fn` function.

## Problem
The function had two UB issues:
1. **NULL pointer arithmetic**: `strrchr(fn, c) + 1` when `strrchr` returns NULL
2. **NULL pointer comparison**: `fn < off` when `off` is NULL

This caused crashes in debug builds as reported by @InBetweenNames.

## Solution
Changed the logic to safely handle NULL returns from `strrchr()`:

**Before:**
```c
const char* off = strrchr(fn, c) + 1;
fn = (fn < off) ? off : fn;