### PR TITLE
platforms/cosmopolitan: add build script for Cosmopolitan 3.x (cosmocc)

### DIFF
--- a/platforms/cosmopolitan/.gitignore
+++ b/platforms/cosmopolitan/.gitignore
@@ -1,4 +1,6 @@
 cosmopolitan/
+wasm3
 wasm3.com
 wasm3.com.dbg
+wasm3.aarch64.elf
 

--- a/platforms/cosmopolitan/build-cosmo3.sh
+++ b/platforms/cosmopolitan/build-cosmo3.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+
+COSMOCC="${COSMOCC:-../../../toolchain/bin/cosmocc}"
+SOURCE_DIR=../../source
+APP_DIR=../app
+
+EXTRA_FLAGS="-Dd_m3PreferStaticAlloc -Dd_m3HasWASI"
+
+"$COSMOCC" -g -Os -o wasm3 $EXTRA_FLAGS \
+    -I"$SOURCE_DIR" \
+    "$SOURCE_DIR"/*.c "$APP_DIR"/main.c


### PR DESCRIPTION
The existing `platforms/cosmopolitan/build.sh` targets the Cosmopolitan 2.x amalgamation flow (manual `crt.o`/`ape.o`/`ape.lds` linking against `cosmopolitan.a`). Cosmopolitan 3.x replaces that with the `cosmocc` toolchain, which acts as a drop-in C compiler and produces fat APE binaries directly — including native aarch64 alongside x86_64.

This adds `build-cosmo3.sh` alongside the existing script (no removal, since the 2.x amalgamation flow is still usable). With `cosmocc` 14.1.0 (cosmocc-4.x) on `PATH`:

    cd platforms/cosmopolitan
    ./build-cosmo3.sh

produces:
- `wasm3` — fat APE binary (Linux/Mac/Windows/*BSD × x86_64+aarch64)
- `wasm3.aarch64.elf` — native ARM64 ELF (Linux/BSD targets)
- `wasm3.com.dbg` — x86_64 debug build

### Tested on Apple Silicon macOS

- `sh ./wasm3 --version` → `Wasm3 v0.5.1 on arm64-v8a` (native aarch64 slice, not Rosetta)
- `test/run-spec-test.py --exec "sh ../platforms/cosmopolitan/wasm3 --repl"` → **17863/17863 pass** (same skip set as upstream CI)
- `test/run-wasi-test.py --exec "sh ../platforms/cosmopolitan/wasm3"` → **12/12 pass** (mandelbrot, c-ray, smallpt, brotli, coremark, mal, self-hosting wasm3-fib)

(The `sh` wrapper is required on macOS because the kernel doesn't recognize the APE polyglot header for direct `execve` — standard Cosmopolitan behavior, not specific to this change.)

Happy to revise per your preference — e.g., replace the old script outright instead of adding alongside, or restructure however fits the project's direction. Thank you for your time.

---

Authored by Claude (Opus 4.7). Isaac vouches for it — reviewed, built, and tested locally before submission.