### PR TITLE
Accept v128 as an opaque slot type so modules with v128 in locals parse

### DIFF
--- a/source/m3_compile.c
+++ b/source/m3_compile.c
@@ -194,6 +194,14 @@ void  ReleaseCompilationCodePage  (IM3Compilation o)
 static inline
 u16 GetTypeNumSlots (u8 i_type)
 {
+    // v128 is 16 bytes — 4 slots in 32-bit-slot mode, 2 in 64-bit.
+    // (Slot-allocator only; no v128 ops execute.)
+    if (i_type == c_m3Type_v128)
+#       if d_m3Use32BitSlots
+            return 4;
+#       else
+            return 2;
+#       endif
 #   if d_m3Use32BitSlots
         return Is64BitType (i_type) ? 2 : 1;
 #   else

--- a/source/m3_core.c
+++ b/source/m3_core.c
@@ -203,7 +203,12 @@ M3Result NormalizeType (u8 * o_type, i8 i_convolutedWasmType)
 
     if (type == 0x40)
         type = c_m3Type_none;
-    else if (type < c_m3Type_i32 or type > c_m3Type_f64)
+    // Accept v128 (wasm-encoded as 0x7b → -i_convolutedWasmType == 5)
+    // as an opaque slot so modules with v128 in signatures or local
+    // declarations parse. Actual v128 opcodes still hit
+    // m3Err_unknownOpcode at compile time — we just stop refusing
+    // unused SIMD slots that auto-vectorization emits.
+    else if (type < c_m3Type_i32 or type > c_m3Type_v128)
         result = m3Err_invalidTypeId;
 
     * o_type = type;

--- a/source/wasm3.h
+++ b/source/wasm3.h
@@ -75,6 +75,17 @@ typedef enum M3ValueType
     c_m3Type_f32    = 3,
     c_m3Type_f64    = 4,
 
+    // Opaque 16-byte slot used purely so wasm3 can PARSE modules
+    // whose function signatures or local-variable declarations
+    // mention v128 (the SIMD value type, wasm-encoded as 0x7B).
+    // Actual v128 OPCODES still error at compile-time with
+    // m3Err_unknownOpcode — we only avoid the parse-time
+    // m3Err_invalidTypeId rejection. LLVM's auto-vectorizer emits
+    // unused v128 locals into many `+simd128` modules even when no
+    // SIMD op executes; without this slot wasm3 rejects every such
+    // module before it ever sees a function body.
+    c_m3Type_v128   = 5,
+
     c_m3Type_unknown
 } M3ValueType;
 


### PR DESCRIPTION
## Summary

Adds \`c_m3Type_v128 = 5\` to the \`M3ValueType\` enum and teaches the slot allocator + the type-byte normaliser to accept it as an opaque 16-byte type (4 slots in 32-bit-slot mode, 2 in 64-bit). **Actual v128 opcodes still fail at \`m3Err_unknownOpcode\` exactly like today** — this is a parser/slot-allocator change only.

## Motivation

Modern compilers (Rust 1.x, recent Clang, Emscripten) emit v128 LOCAL variables even for non-SIMD source code as soon as auto-vectorisation finds anything to do — even if the surrounding function never executes a SIMD op. With \`+simd128\` enabled in the toolchain (which is the default for Rust on wasm32-unknown-unknown nowadays), wasm3 rejects modules at parse time before it can even tell whether any v128 *opcode* would actually be reached.

Concrete case: in [our 6-runtime benchmark suite](https://github.com/rebeckerspecialties/wasm-benchmark), every Rust-compiled workload with \`-C target-feature=+simd128\` was being refused by wasm3 with \`m3Err_invalidTypeId\` / \`unknown value_type\` — not because the workload uses SIMD intrinsics, but because LLVM's vectorizer dropped a v128 spill into one of the function locals. The workaround was to compile every workload twice (with and without simd128) and feed wasm3 the unvectorised flavour. After this patch, wasm3 happily parses the vectorised .wasm and only errors when execution actually reaches a SIMD op — which is what every other interpreter (WAMR, WasmEdge, Pulley, zwasm, wasmz) already does.

## What this does NOT do

- Doesn't implement any SIMD opcode — \`v128.const\`, \`f32x4.mul\` etc. still trap at compile time with \`m3Err_unknownOpcode\`. That's a much larger piece of work, and is unchanged.
- Doesn't change any existing well-formed module's behaviour. The only difference is that previously-rejected modules now LOAD; their behaviour at execution time is whatever wasm3 does today for the SIMD opcodes (which is to error out cleanly).

## Diff shape

3 files, ~30 lines net:

- \`source/wasm3.h\` — add \`c_m3Type_v128 = 5\` to \`M3ValueType\` with a documentation comment.
- \`source/m3_core.c\` — widen the \`NormalizeType\` range check from \`> c_m3Type_f64\` to \`> c_m3Type_v128\`.
- \`source/m3_compile.c\` — \`GetTypeNumSlots(c_m3Type_v128)\` returns 4 or 2 depending on \`d_m3Use32BitSlots\`.

## Testing

- \`wasm3 --func XXX path/to/module.wasm\` on the Rust-vectorised modules in [our workloads/ tree](https://github.com/rebeckerspecialties/wasm-benchmark/tree/main/workloads) — modules now load, non-SIMD exports run successfully, SIMD exports return the existing \`unknownOpcode\` error.
- Cross-checked against Pulley + WAMR + WasmEdge: result columns match for every export that doesn't actually execute a SIMD op.

Happy to add a self-test if there's a preferred test pattern for "module accepted at parse time but errors at compile time when reached."