### PR TITLE
Add validation guidance for untrusted WebAssembly modules

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -11,6 +11,10 @@ python3 ./run-spec-test.py
 
 It will automatically download, extract, run the WebAssembly core test suite.
 
+## WebAssembly validation
+
+Wasm3 is not a complete WebAssembly validator. Before running untrusted modules, validate them with an external tool and see [VALIDATION.md](./VALIDATION.md).
+
 ## Running WASI test
 
 Wasm3 comes with a set of benchmarks and test programs (prebuilt as `WASI` apps) including `CoreMark`, `C-Ray`, `Brotli`, `mandelbrot`, `smallpt` and `wasm3` itself.
@@ -58,4 +62,3 @@ Note: to catch fuzzer errors in debugger, you need to define:
 export ASAN_OPTIONS=abort_on_error=1
 export UBSAN_OPTIONS=abort_on_error=1
 ```
-

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,0 +1,21 @@
+# WebAssembly validation
+
+Wasm3 performs many parsing and runtime checks, but it is not a complete WebAssembly validator. Some malformed or invalid modules may be rejected late, fail with a runtime error, or hit rough edges before the full validation work is merged.
+
+## Untrusted modules
+
+Do not run untrusted `.wasm` modules with Wasm3 unless they have been validated by an external tool first.
+
+Useful external validators include:
+
+- `wasm-validate` from [WABT](https://github.com/WebAssembly/wabt)
+- `wasm-tools validate` from [wasm-tools](https://github.com/bytecodealliance/wasm-tools)
+- `wat2wasm` / `wast2json` from WABT for text-format and spec-test inputs
+
+If a module does not pass validation with an external validator, do not feed it to Wasm3.
+
+## Current status
+
+A more complete validator is being developed in the `validation` branch. Cheap structural checks are intended to remain available even when more expensive validation is disabled. If validation can be disabled in a particular build or configuration, treat that mode as suitable only for trusted inputs.
+
+When reporting validation-related issues, include the offending module or a minimal reproducer, whether it validates with external tools, and the Wasm3 revision/build options.


### PR DESCRIPTION
Adds `docs/VALIDATION.md` explaining that Wasm3 is not a complete validator and that untrusted modules should be validated externally before use. Also links the new document from `docs/Testing.md` so people running tests or untrusted inputs see the warning.

This is the small documentation pass discussed in #344 while the more complete validation work continues.

Addresses #344