### PR TITLE
Update build.zig to v0.16.0

### DIFF
--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -1,0 +1,82 @@
+name: zig
+
+on:
+  push:
+    branches: ["**"]
+    tags: ["v*.*.*"]
+    paths-ignore: ['**.md', '**.svg', '**.png']
+  pull_request:
+    paths-ignore: ['**.md', '**.svg', '**.png']
+  workflow_dispatch:
+
+jobs:
+  native:
+    name: zig-native-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            py: python3
+          - os: macos-latest
+            py: python3
+          - os: windows-latest
+            py: python
+    steps:
+      - uses: actions/checkout@v7
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - name: Build
+        run: zig build -Doptimize=ReleaseFast -Dbuild_wasi=simple
+      - name: Test WebAssembly spec
+        working-directory: test
+        run: ${{ matrix.py }} run-spec-test.py --exec "../zig-out/bin/wasm3 --spec-repl"
+      - name: Test WASI apps
+        working-directory: test
+        run: ${{ matrix.py }} run-wasi-test.py --fast --exec ../zig-out/bin/wasm3
+
+  wasi:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.16.0
+      - name: Install Wasmtime
+        run: curl https://wasmtime.dev/install.sh -sSf | bash
+      - name: Build (native)
+        run: zig build -Doptimize=ReleaseFast -Dbuild_wasi=simple
+      - name: Build (wasm32-wasi, metawasi)
+        run: zig build -Doptimize=ReleaseFast -Dtarget=wasm32-wasi -Dbuild_wasi=metawasi
+      - name: Prepare wasm
+        run: |
+          cp zig-out/bin/wasm3.wasm ./test/wasm3.wasm
+          cp zig-out/bin/wasm3.wasm ./wasm3-wasi-zig.wasm
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: wasm3-wasi-zig
+          path: ./wasm3-wasi-zig.wasm
+          if-no-files-found: error
+      - name: Test WebAssembly spec (in Wasmtime)
+        run: |
+          export PATH="$HOME/.wasmtime/bin:$PATH"
+          cd test
+          python3 run-spec-test.py --exec "wasmtime run -W max-wasm-stack=4194304 --dir ./::./ wasm3.wasm --spec-repl"
+      - name: Test WASI apps (in Wasmtime)
+        run: |
+          export PATH="$HOME/.wasmtime/bin:$PATH"
+          cd test
+          python3 run-wasi-test.py --fast --exec "wasmtime run -W max-wasm-stack=4194304 --dir ./::./ wasm3.wasm"
+      - name: Test WebAssembly spec (self-hosting)
+        run: |
+          cd test
+          python3 run-spec-test.py --exec "../zig-out/bin/wasm3 --stack-size 2097152 wasm3.wasm --spec-repl"
+      - name: Test WASI apps (self-hosting)
+        run: |
+          cd test
+          python3 run-wasi-test.py --fast --exec "../zig-out/bin/wasm3 --stack-size 2097152 wasm3.wasm"

--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -48,8 +48,8 @@ jobs:
           version: 0.16.0
       - name: Install Wasmtime
         run: curl https://wasmtime.dev/install.sh -sSf | bash
-      - name: Build (native)
-        run: zig build -Doptimize=ReleaseFast -Dbuild_wasi=simple
+      # Self-hosting tests are deferred until build.zig supports uvwasi
+      # The CMake CI runs them against a uvwasi host, which the zig build cannot provide yet
       - name: Build (wasm32-wasi, metawasi)
         run: zig build -Doptimize=ReleaseFast -Dtarget=wasm32-wasi -Dbuild_wasi=metawasi
       - name: Prepare wasm
@@ -72,11 +72,3 @@ jobs:
           export PATH="$HOME/.wasmtime/bin:$PATH"
           cd test
           python3 run-wasi-test.py --fast --exec "wasmtime run -W max-wasm-stack=4194304 --dir ./::./ wasm3.wasm"
-      - name: Test WebAssembly spec (self-hosting)
-        run: |
-          cd test
-          python3 run-spec-test.py --exec "../zig-out/bin/wasm3 --stack-size 2097152 wasm3.wasm --spec-repl"
-      - name: Test WASI apps (self-hosting)
-        run: |
-          cd test
-          python3 run-wasi-test.py --fast --exec "../zig-out/bin/wasm3 --stack-size 2097152 wasm3.wasm"

--- a/.github/workflows/zig-build.yml
+++ b/.github/workflows/zig-build.yml
@@ -1,9 +1,11 @@
-name: zig
+name: zig-build
 
 on:
   push:
-    branches: ["**"]
-    tags: ["v*.*.*"]
+    branches:
+    - "**"
+    tags:
+    - "v*.*.*"
     paths-ignore: ['**.md', '**.svg', '**.png']
   pull_request:
     paths-ignore: ['**.md', '**.svg', '**.png']
@@ -48,7 +50,7 @@ jobs:
           version: 0.16.0
       - name: Install Wasmtime
         run: curl https://wasmtime.dev/install.sh -sSf | bash
-      # Self-hosting tests are deferred until build.zig supports uvwasi
+      # Self-hosting tests are deferred until build.zig supports uvwasi.
       # The CMake CI runs them against a uvwasi host, which the zig build cannot provide yet
       - name: Build (wasm32-wasi, metawasi)
         run: zig build -Doptimize=ReleaseFast -Dtarget=wasm32-wasi -Dbuild_wasi=metawasi

--- a/build.zig
+++ b/build.zig
@@ -21,7 +21,7 @@ pub fn build(b: *std.Build) !void {
     if (build_wasi) |wasi| {
         switch (wasi) {
             .simple => libwasm3.root_module.addCMacro("d_m3HasWASI", ""),
-            .metawasi => libwasm3.root_module.addCMacro("d_m3HasWASI", ""),
+            .metawasi => libwasm3.root_module.addCMacro("d_m3HasMetaWASI", ""),
             .uvwasi => @panic("build.zig does not yet support this option."),
         }
     }
@@ -83,7 +83,7 @@ pub fn build(b: *std.Build) !void {
         if (build_wasi) |wasi| {
             switch (wasi) {
                 .simple => wasm3.root_module.addCMacro("d_m3HasWASI", ""),
-                .metawasi => wasm3.root_module.addCMacro("d_m3HasWASI", ""),
+                .metawasi => wasm3.root_module.addCMacro("d_m3HasMetaWASI", ""),
                 .uvwasi => @panic("build.zig does not yet support this option."),
             }
         }

--- a/build.zig
+++ b/build.zig
@@ -5,23 +5,33 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const libm3_only = b.option(bool, "libm3", "Build libwasm3 only") orelse false;
+    const build_wasi = b.option(enum {simple, metawasi, uvwasi}, "build_wasi", "How to enable wasi");
 
-    const libwasm3 = b.addStaticLibrary(.{
+    const libwasm3 = b.addLibrary(.{
+        .linkage = .static,
         .name = "m3",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .optimize = optimize,
+            .target = target,
+            .sanitize_c = .off, // fno-sanitize=undefined
+        }),
     });
-    libwasm3.root_module.sanitize_c = false; // fno-sanitize=undefined
-    libwasm3.defineCMacro("d_m3HasTracer", null);
+    libwasm3.root_module.addCMacro("d_m3HasTracer", "");
 
-    if (libwasm3.rootModuleTarget().isWasm()) {
-        if (libwasm3.rootModuleTarget().os.tag == .wasi) {
-            libwasm3.defineCMacro("d_m3HasWASI", null);
-            libwasm3.linkSystemLibrary("wasi-emulated-process-clocks");
+    if (build_wasi) |wasi| {
+        switch (wasi) {
+            .simple => libwasm3.root_module.addCMacro("d_m3HasWASI", ""),
+            .metawasi => libwasm3.root_module.addCMacro("d_m3HasWASI", ""),
+            .uvwasi => @panic("build.zig does not yet support this option."),
         }
     }
-    libwasm3.addIncludePath(b.path("source"));
-    libwasm3.addCSourceFiles(.{
+    if (libwasm3.rootModuleTarget().cpu.arch.isWasm()) {
+        if (libwasm3.rootModuleTarget().os.tag == .wasi) {
+            libwasm3.root_module.linkSystemLibrary("wasi-emulated-process-clocks", .{});
+        }
+    }
+    libwasm3.root_module.addIncludePath(b.path("source"));
+    libwasm3.root_module.addCSourceFiles(.{
         .files = &.{
             "source/m3_api_libc.c",
             "source/extensions/m3_extensions.c",
@@ -32,6 +42,7 @@ pub fn build(b: *std.Build) !void {
             "source/m3_bind.c",
             "source/m3_code.c",
             "source/m3_compile.c",
+            "source/m3_validate.c",
             "source/m3_core.c",
             "source/m3_env.c",
             "source/m3_exec.c",
@@ -40,7 +51,7 @@ pub fn build(b: *std.Build) !void {
             "source/m3_module.c",
             "source/m3_parse.c",
         },
-        .flags = if (libwasm3.rootModuleTarget().isWasm())
+        .flags = if (libwasm3.rootModuleTarget().cpu.arch.isWasm())
             &cflags ++ [_][]const u8{
                 "-Xclang",
                 "-target-feature",
@@ -50,24 +61,33 @@ pub fn build(b: *std.Build) !void {
         else
             &cflags,
     });
-    libwasm3.linkSystemLibrary("m");
-    libwasm3.linkLibC();
+    libwasm3.root_module.linkSystemLibrary("m", .{});
+    libwasm3.root_module.link_libc = true;
 
     if (!libm3_only) {
         const wasm3 = b.addExecutable(.{
             .name = "wasm3",
-            .target = target,
-            .optimize = optimize,
+            .root_module = b.createModule(.{
+                .target = target,
+                .optimize = optimize,
+            }),
         });
         for (libwasm3.root_module.include_dirs.items) |dir| {
-            wasm3.addIncludePath(dir.path);
+            wasm3.root_module.addIncludePath(dir.path);
         }
-        wasm3.addCSourceFile(.{
+        wasm3.root_module.addCSourceFile(.{
             .file = .{ .cwd_relative = "platforms/app/main.c" },
             .flags = &cflags,
         });
 
-        wasm3.linkLibrary(libwasm3);
+        if (build_wasi) |wasi| {
+            switch (wasi) {
+                .simple => wasm3.root_module.addCMacro("d_m3HasWASI", ""),
+                .metawasi => wasm3.root_module.addCMacro("d_m3HasWASI", ""),
+                .uvwasi => @panic("build.zig does not yet support this option."),
+            }
+        }
+        wasm3.root_module.linkLibrary(libwasm3);
         b.installArtifact(wasm3);
     } else b.installArtifact(libwasm3);
 }

--- a/build.zig
+++ b/build.zig
@@ -13,10 +13,15 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{
             .optimize = optimize,
             .target = target,
+            .omit_frame_pointer = if (optimize == .Debug) null else true,
+            .stack_check = if (optimize == .Debug) null else false,
+            .stack_protector = if (optimize == .Debug) null else false,
             .sanitize_c = .off, // fno-sanitize=undefined
         }),
     });
     libwasm3.root_module.addCMacro("d_m3HasTracer", "");
+    if (optimize == .Debug)
+        libwasm3.root_module.addCMacro("DEBUG", "1");
 
     if (build_wasi) |wasi| {
         switch (wasi) {
@@ -27,6 +32,7 @@ pub fn build(b: *std.Build) !void {
     }
     if (libwasm3.rootModuleTarget().cpu.arch.isWasm()) {
         if (libwasm3.rootModuleTarget().os.tag == .wasi) {
+            libwasm3.root_module.addCMacro("_WASI_EMULATED_PROCESS_CLOCKS", "");
             libwasm3.root_module.linkSystemLibrary("wasi-emulated-process-clocks", .{});
         }
     }
@@ -57,6 +63,31 @@ pub fn build(b: *std.Build) !void {
                 "-target-feature",
                 "-Xclang",
                 "+tail-call",
+
+                "-Xclang",
+                "-target-feature",
+                "-Xclang",
+                "+bulk-memory",
+
+                "-Xclang",
+                "-target-feature",
+                "-Xclang",
+                "+nontrapping-fptoint",
+
+                "-Xclang",
+                "-target-feature",
+                "-Xclang",
+                "+sign-ext",
+
+                "-Xclang",
+                "-target-feature",
+                "-Xclang",
+                "+multivalue",
+
+                "-Xclang",
+                "-target-feature",
+                "-Xclang",
+                "+mutable-globals",
             }
         else
             &cflags,
@@ -70,8 +101,12 @@ pub fn build(b: *std.Build) !void {
             .root_module = b.createModule(.{
                 .target = target,
                 .optimize = optimize,
+                .omit_frame_pointer = if (optimize == .Debug) null else true,
+                .stack_check = if (optimize == .Debug) null else false,
+                .stack_protector = if (optimize == .Debug) null else false,
             }),
         });
+        wasm3.stack_size = 8388608;
         for (libwasm3.root_module.include_dirs.items) |dir| {
             wasm3.root_module.addIncludePath(dir.path);
         }
@@ -79,6 +114,9 @@ pub fn build(b: *std.Build) !void {
             .file = .{ .cwd_relative = "platforms/app/main.c" },
             .flags = &cflags,
         });
+        wasm3.root_module.addCMacro("d_m3HasTracer", "");
+        if (optimize == .Debug)
+            wasm3.root_module.addCMacro("DEBUG", "1");
 
         if (build_wasi) |wasi| {
             switch (wasi) {
@@ -95,10 +133,15 @@ pub fn build(b: *std.Build) !void {
 const cflags = [_][]const u8{
     "-Wall",
     "-Wextra",
-    "-Wpedantic",
     "-Wparentheses",
     "-Wundef",
     "-Wpointer-arith",
     "-Wstrict-aliasing=2",
-    "-std=gnu11",
+    "-Werror=implicit-function-declaration",
+    "-Wno-unused-function",
+    "-Wno-unused-variable",
+    "-Wno-unused-parameter",
+    "-Wno-date-time",
+    "-Wno-missing-field-initializers",
+    "-std=gnu99",
 };

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,19 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const libm3_only = b.option(bool, "libm3", "Build libwasm3 only") orelse false;
-    const build_wasi = b.option(enum {simple, metawasi, uvwasi}, "build_wasi", "How to enable wasi");
+
+    const BuildWasiOptions = enum { none, simple, metawasi, uvwasi };
+    const build_wasi: BuildWasiOptions = b.option(BuildWasiOptions, "build_wasi", "How to enable wasi") orelse default: {
+        if (target.result.cpu.arch.isWasm() and
+            target.result.os.tag == .wasi) break :default .metawasi;
+        if (target.result.os.tag != .freestanding) break :default .simple;
+        break :default .none;
+    };
+
+    if (build_wasi == .metawasi) {
+        if (!target.result.cpu.arch.isWasm() or
+            target.result.os.tag != .wasi) @panic("MetaWASI is only supported on WASI target");
+    }
 
     const libwasm3 = b.addLibrary(.{
         .linkage = .static,
@@ -23,13 +35,13 @@ pub fn build(b: *std.Build) !void {
     if (optimize == .Debug)
         libwasm3.root_module.addCMacro("DEBUG", "1");
 
-    if (build_wasi) |wasi| {
-        switch (wasi) {
-            .simple => libwasm3.root_module.addCMacro("d_m3HasWASI", ""),
-            .metawasi => libwasm3.root_module.addCMacro("d_m3HasMetaWASI", ""),
-            .uvwasi => @panic("build.zig does not yet support this option."),
-        }
+    switch (build_wasi) {
+        .simple => libwasm3.root_module.addCMacro("d_m3HasWASI", ""),
+        .metawasi => libwasm3.root_module.addCMacro("d_m3HasMetaWASI", ""),
+        .uvwasi => @panic("build.zig does not yet support this option."),
+        else => {},
     }
+
     if (libwasm3.rootModuleTarget().cpu.arch.isWasm()) {
         if (libwasm3.rootModuleTarget().os.tag == .wasi) {
             libwasm3.root_module.addCMacro("_WASI_EMULATED_PROCESS_CLOCKS", "");
@@ -118,13 +130,13 @@ pub fn build(b: *std.Build) !void {
         if (optimize == .Debug)
             wasm3.root_module.addCMacro("DEBUG", "1");
 
-        if (build_wasi) |wasi| {
-            switch (wasi) {
-                .simple => wasm3.root_module.addCMacro("d_m3HasWASI", ""),
-                .metawasi => wasm3.root_module.addCMacro("d_m3HasMetaWASI", ""),
-                .uvwasi => @panic("build.zig does not yet support this option."),
-            }
+        switch (build_wasi) {
+            .simple => wasm3.root_module.addCMacro("d_m3HasWASI", ""),
+            .metawasi => wasm3.root_module.addCMacro("d_m3HasMetaWASI", ""),
+            .uvwasi => @panic("build.zig does not yet support this option."),
+            else => {},
         }
+
         wasm3.root_module.linkLibrary(libwasm3);
         b.installArtifact(wasm3);
     } else b.installArtifact(libwasm3);


### PR DESCRIPTION
### Reason
 The previous build.zig does not work with the current stable version of Zig (v0.16.0).

### Change
- Update build API to Zig 0.16.0
- Add the `-Dbuild_wasi` option to enable wasi support

### Incomplete
The `-Dbuild_wasi` option does not support `uvwasi` yet. I need more time to study the cmake scripts and migrate additional build options. Sorry, I am not familiar with cmake.